### PR TITLE
FIX: Updated Covid series selection to choose Pfizer schedule instead…

### DIFF
--- a/src/main/resources/rules/v1.38.1.1/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^SeriesSelection.drl
+++ b/src/main/resources/rules/v1.38.1.1/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^SeriesSelection.drl
@@ -1110,7 +1110,7 @@ rule "SeriesSelection(COVID-19): If all administered doses are a Pfizer vaccine,
 	when
 		$tss : TargetSeriesSelection(seriesSelectionVaccineGroup == "VACCINE_GROUP_CONCEPT.850", seriesSelectionStatus == SeriesSelectionStatus.SERIES_SELECTION_IN_PROCESS)
 		not TargetSeries(seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.850", selectedSeries == true)
-		exists TargetDose(associatedVaccineGroup == "VACCINE_GROUP_CONCEPT.850", isValid == true, associatedTargetSeries.seriesRules.seriesName == "COVID19PfizerSeries")
+		exists TargetDose(associatedVaccineGroup == "VACCINE_GROUP_CONCEPT.850",  associatedTargetSeries.seriesRules.seriesName == "COVID19PfizerSeries")
 		not TargetDose(associatedVaccineGroup == "VACCINE_GROUP_CONCEPT.850", isValid == true, vaccineComponent.cdsConceptName not in ("ICE208", "ICE217", "ICE218", "ICE219", "ICE300", "ICE301", "ICE302"))
 		not TargetDose(associatedVaccineGroup == "VACCINE_GROUP_CONCEPT.850", vaccineComponent.isUnspecifiedFormulation() == true)
 		$tspfizer : TargetSeries(seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.850", seriesRules.seriesName == "COVID19PfizerSeries")


### PR DESCRIPTION
… of mixed series when only 1 covid is given and it is an invalid pfizer.