### PR TITLE
Adding doses to 2 Covid series and changes to covid evaluation rules.

### DIFF
--- a/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Evaluation^COVID-19.dslr
+++ b/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Evaluation^COVID-19.dslr
@@ -801,7 +801,7 @@ rule "COVID-19: If the first bivalent dose on >= 3/17/2023 and < 9/12/2023 after
 			- the numeric $doseNumberCurrentShot is == 2
 		Confirm elapsed time between $priorShotDate and $currentShotDate < "3w"
 	then
-		Include Supplemental Text "The timing of the administration of this shot does not follow the guidelines regarding the minimum interval of 3 weeks." for Valid Shot $currentShot
+		Include the reason for shot $currentShot Invalid due to "Below Minimum Interval"
 		Record that this dose rule was Processed for the TargetDose $currentShot
         Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
@@ -818,7 +818,7 @@ rule "COVID-19: If the second bivalent dose on >= 3/17/2023 and < 9/12/2023 afte
 			- the numeric $doseNumberCurrentShot is == 3
 		Confirm elapsed time between $priorShotDate and $currentShotDate < "4w"
 	then
-		Include Supplemental Text "The timing of the administration of this shot does not follow the guidelines regarding the minimum interval of 4 weeks." for Valid Shot $currentShot
+		Include the reason for shot $currentShot Invalid due to "Below Minimum Interval"
 		Record that this dose rule was Processed for the TargetDose $currentShot
         Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
@@ -834,7 +834,7 @@ rule "COVID-19: If the third or greater bivalent dose on >= 3/17/2023 and < 9/12
 			- the numeric $doseNumberCurrentShot is >= 4
 		Confirm elapsed time between $priorShotDate and $currentShotDate < "8w"
 	then
-		Include Supplemental Text "The timing of the administration of this shot does not follow the guidelines regarding the minimum interval of 8 weeks." for Valid Shot $currentShot
+		Include the reason for shot $currentShot Invalid due to "Below Minimum Interval"
 		Record that this dose rule was Processed for the TargetDose $currentShot
         Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
@@ -879,7 +879,7 @@ rule "COVID-19: If the first or second bivalent dose on >= 4/19/2023 and < 9/12/
 			- the numeric $doseNumberCurrentShot is <= 3
 		Confirm elapsed time between $priorShotDate and $currentShotDate < "4w"
 	then
-		Include Supplemental Text "The timing of the administration of this shot does not follow the guidelines regarding the minimum interval of 4 weeks." for Valid Shot $currentShot
+		Include the reason for shot $currentShot Invalid due to "Below Minimum Interval"
 		Record that this dose rule was Processed for the TargetDose $currentShot
         Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
@@ -896,7 +896,7 @@ rule "COVID-19: If the first or second bivalent dose on >= 4/19/2023 and < 9/12/
 			- the numeric $doseNumberCurrentShot is >= 4
 		Confirm elapsed time between $priorShotDate and $currentShotDate < "8w"
 	then
-		Include Supplemental Text "The timing of the administration of this shot does not follow the guidelines regarding the minimum interval of 8 weeks." for Valid Shot $currentShot
+		Include the reason for shot $currentShot Invalid due to "Below Minimum Interval"
 		Record that this dose rule was Processed for the TargetDose $currentShot
         Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
@@ -967,7 +967,7 @@ rule "COVID-19: If a 2nd bivalent dose was administered to a patient >= 65 yrs o
 		Confirm elapsed time between $priorShotDate and $latestShotDate < "4m"
 		Confirm that the following is true: $nDosesAdministeredAfter041923 >= 1 && $nDosesAdministeredAfter041923 <= 2 && ($nNumberOfBivalentDoses + $nDosesAdministeredAfter041923 >= 2)
 	then
-		Include Supplemental Text "The timing of the administration of this shot does not follow the guidelines regarding the minimum interval of 4 months." for Valid Shot $latestShot
+		Include the reason for shot $latestShot Invalid due to "Below Minimum Interval"
 		Record that this dose rule was Processed for the TargetDose $latestShot
         Log that this dose rule fired for the dose $latestShot in the Series $associatedTargetSeries
 end
@@ -1041,7 +1041,6 @@ rule "COVID-19: If the patient has not received a valid Fall 2023 vaccine and th
 			- make note of the date this shot was administered as $currentShotDate
 			- make note of the associated series as $associatedTargetSeries
 		There is a Series $targetSeries identified by $associatedTargetSeries
-			- the name of the Series a member of ("COVID19ModernaSeries", "COVID19MixedProductSeries", "COVID19PfizerSeries", "COVID19Janssen1DoseSeries")
 			- the series is complete
 		There does not exist an administered shot
 			- the shot belongs to the Series $targetSeries
@@ -1321,6 +1320,34 @@ rule "COVID-19: If the patient received a (valid) dose ICE309 or ICE312 in the M
 		Record that this Series Rule was Processed for the TargetSeries $targetSeries
 		Log that this Series Rule fired for the Series $targetSeries
 
+end
+
+rule "COVID-19: Supplemental Text- If a Fall 2023 shot is administered >= 09/12/2023  < 8 weeks after prior dose, include supplemental text that follows guidelines regarding minimum ages/intervals"
+	dialect "mvel"
+	agenda-group "HistoryEvaluation^postEvaluationCheck"
+	when
+		There is a Series $targetSeries
+			- the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.850"
+			- the series is complete
+		There is an administered shot $administeredShot
+			- the shot belongs to the series $targetSeries
+			- that has already been evaluated and whose Shot Validity Status is VALID
+			- the administration date of the shot is >= "12-Sep-2023"
+			- make note of the date this shot was administered as $currentShotDate
+			- make note of the associated series as $associatedTargetSeries
+		There is an administered shot $priorShot
+			- the shot belongs to the series $targetSeries
+			- the administration date of the shot is < $currentShotDate
+			- make note of the date this shot was administered as $priorShotDate
+		There does not exist an administered shot
+			- the shot belongs to the series $targetSeries
+			- the administration date of the shot is > $priorShotDate
+			- the administration date of the shot is < $currentShotDate
+		Confirm elapsed time between $priorShotDate and $currentShotDate < "8w"
+	then
+		Include Supplemental Text "The timing of the administration of this shot does not follow the guidelines regarding the minimum interval of 8 weeks required for the 1st Booster Dose." for Valid Shot $administeredShot
+		Record that this dose rule was Processed for the TargetDose $administeredShot
+        Log that this dose rule fired for the dose $administeredShot in the Series $targetSeries
 end
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^SeriesSelection.drl
+++ b/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^SeriesSelection.drl
@@ -927,26 +927,7 @@ end
 // This is the only way a non-FDA, WHO-approved series can be selected (it must be complete).
 // If there is more than one series that has been complete, this rule picks one of them, and the general rules will pick the earliest completed.
 ///////// ***
-rule "SeriesSelection(COVID-19): Select already _completed_ series if a different, _incomplete_ series was previously selected"
-	dialect "mvel"
-	agenda-group "SeriesSelection^customSeriesSelectionRules"
-	salience 5
-	when
-		$tss : TargetSeriesSelection(seriesSelectionVaccineGroup == "VACCINE_GROUP_CONCEPT.850", seriesSelectionStatus == SeriesSelectionStatus.SERIES_SELECTION_IN_PROCESS || seriesSelectionStatus == SeriesSelectionStatus.SERIES_SELECTION_IN_POSTPROCESS)
-		$ts1 : TargetSeries(seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.850", selectedSeries == true, isSeriesComplete() == false) 
-		$ts2 : TargetSeries(seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.850", selectedSeries == false, isSeriesComplete() == true) 
-	then
-		String _RULENAME = kcontext.rule.name;
-		$ts1.setSelectedSeries(false);
-		$ts2.setSelectedSeries(true);
-		$tss.setSelectedSeriesName($ts2.seriesName);
-		// Do not mark it complete, in case there is another a series that was completed earlier than this one - rather, place it into post-processing
-		$tss.setSeriesSelectionStatus(SeriesSelectionStatus.SERIES_SELECTION_IN_POSTPROCESS);
-		ICELogicHelper.logDRLDebugMessage(_RULENAME, "Previously Selected TargetSeries Reverted. Newly selected series: " + $ts2);
-		update($tss);
-		update($ts1);
-		update($ts2);
-end
+
 
 
 rule "SeriesSelection(COVID-19): If the earliest, non-NOS (Valid) _dose_ was not found in the Pfizer, Moderna, Mixed Product or Janssen series (see related rules), then select the another (i.e. - WHO series) that has the earliest, non-NOS (Valid) _dose_ administered to it"

--- a/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/COVID19MixedProductSeries.xml
+++ b/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/COVID19MixedProductSeries.xml
@@ -19,7 +19,14 @@
         <ns2:minimumInterval>8w</ns2:minimumInterval>
         <ns2:earliestRecommendedInterval>8w</ns2:earliestRecommendedInterval>
     </ns2:doseInterval>
-    <ns2:numberOfDosesInSeries>3</ns2:numberOfDosesInSeries>
+    <ns2:doseInterval>
+        <ns2:fromDoseNumber>3</ns2:fromDoseNumber>
+        <ns2:toDoseNumber>4</ns2:toDoseNumber>
+        <ns2:absoluteMinimumInterval>8w-4d</ns2:absoluteMinimumInterval>
+        <ns2:minimumInterval>8w</ns2:minimumInterval>
+        <ns2:earliestRecommendedInterval>8w</ns2:earliestRecommendedInterval>
+    </ns2:doseInterval>
+    <ns2:numberOfDosesInSeries>4</ns2:numberOfDosesInSeries>
     <ns2:vaccineGroup code="850" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="COVID-19"/>
     <ns2:iceSeriesDose>
         <ns2:doseNumber>1</ns2:doseNumber>
@@ -316,6 +323,56 @@
         <ns2:doseVaccine>
         	<ns2:preferred>false</ns2:preferred>
             <ns2:vaccine code="512" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19 VLP Non-US Vaccine (Medicago, Covifenz)"/>
+        </ns2:doseVaccine>
+    </ns2:iceSeriesDose>
+    <ns2:iceSeriesDose>
+        <ns2:doseNumber>4</ns2:doseNumber>
+        <ns2:absoluteMinimumAge>0d</ns2:absoluteMinimumAge>
+        <ns2:minimumAge>6m</ns2:minimumAge>
+        <ns2:earliestRecommendedAge>6m</ns2:earliestRecommendedAge>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="229" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent booster, PF, 50 mcg/0.5 mL or 25mcg/0.25 mL dose, Moderna"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="230" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent booster, PF, 10 mcg/0.2 mL dose, Moderna"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="300" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent booster, PF, 30 mcg/0.3 mL dose, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="301" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent booster, PF, 10 mcg/0.2 mL dose, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="302" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent, PF, 3 mcg/0.2 mL dose, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="308" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-4 yrs, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="309" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="310" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 5-11 yrs, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="311" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-11 yrs, Moderna"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="312" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Moderna"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="313" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Novavax COVID-19 Vaccine, Adjuvanted"/>
         </ns2:doseVaccine>
     </ns2:iceSeriesDose>
 </ns2:iceSeriesSpecificationFile>

--- a/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/COVID19PfizerSeries.xml
+++ b/src/main/resources/rules/v1.39.2.2/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/COVID19PfizerSeries.xml
@@ -19,7 +19,14 @@
         <ns2:minimumInterval>8w</ns2:minimumInterval>
         <ns2:earliestRecommendedInterval>8w</ns2:earliestRecommendedInterval>
     </ns2:doseInterval>
-    <ns2:numberOfDosesInSeries>3</ns2:numberOfDosesInSeries>
+    <ns2:doseInterval>
+        <ns2:fromDoseNumber>3</ns2:fromDoseNumber>
+        <ns2:toDoseNumber>4</ns2:toDoseNumber>
+        <ns2:absoluteMinimumInterval>8w-4d</ns2:absoluteMinimumInterval>
+        <ns2:minimumInterval>8w</ns2:minimumInterval>
+        <ns2:earliestRecommendedInterval>8w</ns2:earliestRecommendedInterval>
+    </ns2:doseInterval>
+    <ns2:numberOfDosesInSeries>4</ns2:numberOfDosesInSeries>
     <ns2:vaccineGroup code="850" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="COVID-19"/>
     <ns2:iceSeriesDose>
         <ns2:doseNumber>1</ns2:doseNumber>
@@ -143,6 +150,36 @@
         </ns2:doseVaccine>
 		<ns2:doseVaccine>
         	<ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="302" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent, PF, 3 mcg/0.2 mL dose, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="308" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-4 yrs, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="309" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="310" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, 2023-2024 Formula, 5-11 yrs, Pfizer"/>
+        </ns2:doseVaccine>
+    </ns2:iceSeriesDose>
+    <ns2:iceSeriesDose>
+        <ns2:doseNumber>4</ns2:doseNumber>
+        <ns2:absoluteMinimumAge>0d</ns2:absoluteMinimumAge>
+        <ns2:minimumAge>6m</ns2:minimumAge>
+        <ns2:earliestRecommendedAge>6m</ns2:earliestRecommendedAge>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="300" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent booster, PF, 30 mcg/0.3 mL dose, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
+            <ns2:vaccine code="301" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent booster, PF, 10 mcg/0.2 mL dose, Pfizer"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>false</ns2:preferred>
             <ns2:vaccine code="302" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="COVID-19, mRNA, LNP-S, bivalent, PF, 3 mcg/0.2 mL dose, Pfizer"/>
         </ns2:doseVaccine>
         <ns2:doseVaccine>


### PR DESCRIPTION
Removed rule from gov.nyc.cir^ICE^1.0.0^SeriesSelection.drl that selected completed series over non-completed series.