### PR TITLE
Deferred vaccines don't show deferred on Forecast-VacLogic+

### DIFF
--- a/src/main/kotlin/com/connexin/ice/wrapper/Lookups.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/Lookups.kt
@@ -39,6 +39,7 @@ object Lookups {
             Interpretation.IS_IMMUNE -> OID_IS_IMMUNE
             Interpretation.REFUSED -> OID_IS_IMMUNE
             Interpretation.DISEASE -> OID_IS_IMMUNE
+            Interpretation.DEFERRED -> OID_IS_IMMUNE
         }
     }
 

--- a/src/main/kotlin/com/connexin/ice/wrapper/model/Enums.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/model/Enums.kt
@@ -18,7 +18,8 @@ enum class CodeSystem{
 enum class Interpretation{
     IS_IMMUNE,
     REFUSED,
-    DISEASE
+    DISEASE,
+    DEFERRED
 }
 
 enum class ObservationConcept{

--- a/src/main/kotlin/com/connexin/ice/wrapper/model/OPModels.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/model/OPModels.kt
@@ -4,7 +4,16 @@ import java.time.LocalDate
 
 
 data class Vaccine(val id:String,var cvx:String,val name:String,val date:LocalDate)
-data class Indicator(val id:String?=null,val name:String?=null,val code:String,val system: CodeSystem,val interpretation: Interpretation,val date:LocalDate)
+data class Indicator(
+    val id: String? = null,
+    val name: String? = null,
+    val code: String,
+    val system: CodeSystem,
+    val interpretation: Interpretation,
+    val date: LocalDate,
+    val deferredUntil: LocalDate? = null
+)
+
 data class VaccineReport(val gender:Gender,
                          val dateOfBirth: LocalDate,
                          val requestTime: LocalDate,

--- a/src/main/kotlin/com/connexin/ice/wrapper/service/AbstractEngine.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/service/AbstractEngine.kt
@@ -40,7 +40,7 @@ abstract class AbstractEngine() {
             obs.add(
                 VMRObservationResult(it.code,it.system,
                      when(it.interpretation){
-                        Interpretation.REFUSED,Interpretation.IS_IMMUNE -> ObservationConcept.PROOF_OF_IMMUNITY
+                        Interpretation.REFUSED,Interpretation.IS_IMMUNE,Interpretation.DEFERRED -> ObservationConcept.PROOF_OF_IMMUNITY
                         Interpretation.DISEASE -> ObservationConcept.DISEASE_DOCUMENTED
                     },it.interpretation,it.date)
             )


### PR DESCRIPTION
This fix adds a new Interpretation field to handle deferred vaccines from ice-wrapper.