### PR TITLE
PEDS-5341 feat: add new CVX code for a fall 2024 flu vaccine

### DIFF
--- a/src/main/resources/rules/v1.39.2.3/conceptDeterminationMethods/cdm.xml
+++ b/src/main/resources/rules/v1.39.2.3/conceptDeterminationMethods/cdm.xml
@@ -210,13 +210,10 @@
     </conceptMapping>
     <conceptMapping>
       <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-        codeSystemName="OpenCDS concepts" code="ICE320"
-        displayName="influenza, injectable, MDCK, preservative"/>
+        codeSystemName="OpenCDS concepts" code="ICE320" displayName="Influenza, MDCK, trivalent, preservative"/>
       <fromConcepts codeSystem="2.16.840.1.113883.12.292"
-        codeSystemName="Vaccines administered (CVX)"
-        displayName="influenza, injectable, MDCK, preservative">
-        <concept code="320"
-          displayName="influenza, injectable, MDCK, preservative"/>
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, MDCK, trivalent, preservative">
+        <concept code="320" displayName="Influenza, MDCK, trivalent, preservative"/>
       </fromConcepts>
     </conceptMapping>
     <conceptMapping>

--- a/src/main/resources/rules/v1.39.2.3/conceptDeterminationMethods/cdm.xml
+++ b/src/main/resources/rules/v1.39.2.3/conceptDeterminationMethods/cdm.xml
@@ -1,1564 +1,1575 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns2:conceptDeterminationMethods
-	xmlns:ns2="org.opencds.dss.config_rest.v1_0" xmlns:ns3="org.opencds.dss.config.v1_0">
-	<conceptDeterminationMethod code="C36"
-		displayName="Best available OpenCDS concept determination method"
-		codeSystem="2.16.840.1.113883.3.795.12.1.1" version="1.0">
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE17" displayName="Hib NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Hib NOS">
-				<concept code="17" displayName="Hib NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE04" displayName="Measles/Rubella" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Measles/Rubella">
-				<concept code="04" displayName="Measles/Rubella" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE121" displayName="Zoster vaccine, live" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Zoster vaccine, live">
-				<concept code="121" displayName="Zoster vaccine, live" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE187" displayName="Zoster recombinant" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Zoster recombinant">
-				<concept code="187" displayName="Zoster recombinant" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE188" displayName="Zoster, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Zoster, unspecified formulation">
-				<concept code="188" displayName="Zoster, unspecified formulation" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE122" displayName="Rotavirus NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus NOS">
-				<concept code="122" displayName="Rotavirus NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE100"
-				displayName="Pneumococcal Conjugate 7 valent (PCV 7)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate 7 valent (PCV 7)">
-				<concept code="100" displayName="Pneumococcal Conjugate 7 valent (PCV 7)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE995"
-				displayName="Disease Immunity Focus (Measles)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
-				<concept code="055.9" displayName="Measles without mention of complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
-				<concept code="B05.9" displayName="Measles without complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
-				<concept code="371111005" displayName="Serology confirmed measles"/>
-			</fromConcepts>			
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE102" displayName="DTP-Hib-HepB" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTP-Hib-HepB">
-				<concept code="102" displayName="DTP-Hib-HepB" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE133" displayName="Pneumococcal Conjugate NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate 13 valent (PCV 13)">
-				<concept code="133" displayName="Pneumococcal Conjugate 13 valent (PCV 13)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE215" displayName="Pneumococcal conjugate PCV15" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal conjugate PCV15">
-				<concept code="215" displayName="Pneumococcal conjugate PCV15" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE216" displayName="Pneumococcal conjugate PCV20" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal conjugate PCV20">
-				<concept code="216" displayName="Pneumococcal conjugate PCV20" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE43" displayName="HepB adult &gt;= 20yrs" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepB adult &gt;= 20yrs">
-				<concept code="43" displayName="HepB adult &gt;= 20yrs" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE114"
-				displayName="Meningococcal MCV4P (Menactra)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MCV4P (Menactra)">
-				<concept code="114" displayName="Meningococcal MCV4P (Menactra)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE08" displayName="HepB peds &lt;20yrs" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepB peds &lt; 20yrs">
-				<concept code="08" displayName="HepB peds &lt; 20yrs" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE135"
-				displayName="influenza, high dose, seasonal" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, high dose, seasonal">
-				<concept code="135" displayName="influenza, high dose, seasonal" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE22"
-				displayName="DTP-Hib (Tetramune; OmniHib-DTP)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTP-Hib (Tetramune; OmniHib-DTP)">
-				<concept code="22" displayName="DTP-Hib (Tetramune; OmniHib-DTP)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE119"
-				displayName="Rotavirus RV1 (Rotarix, 2 dose)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus RV1 (Rotarix, 2 dose)">
-				<concept code="119" displayName="Rotavirus RV1 (Rotarix, 2 dose)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE161"
-				displayName="influenza, injectable, quadrivalent, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)"
-				displayName="Influenza, injectable, quadrivalent, preservative free, pediatric">
-				<concept code="161"
-					displayName="Influenza, injectable, quadrivalent, preservative free, pediatric" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE166"
-				displayName="influenza, injectable, quadrivalent, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)"
-				displayName="Influenza, injectable, quadrivalent, preservative free, pediatric">
-				<concept code="166"
-					displayName="Influenza, intradermal, quadrivalent, preservative free, injectable" />
-			</fromConcepts>
-		</conceptMapping>		
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE168"
-				displayName="Seasonal trivalent influenza vaccine, adjuvanted, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)"
-				displayName="Seasonal trivalent influenza vaccine, adjuvanted, preservative free ">
-				<concept code="168"
-					displayName="Seasonal trivalent influenza vaccine, adjuvanted, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE170" displayName="DTaP-IPV-Hib" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTaP-IPV-Hib">
-				<concept code="170" displayName="DTaP-IPV-Hib" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE171"	displayName="Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent">
-				<concept code="171"	displayName="Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent" />
-			</fromConcepts>
-		</conceptMapping>		
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE118" displayName="HPV Bivalent (Cervarix)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HPV Bivalent (Cervarix)">
-				<concept code="118" displayName="HPV Bivalent (Cervarix)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE165" displayName="HPV9" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="165" displayName="HPV9" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE48" displayName="Hib-PRP-T (ActHIB, Hiberix)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Hib-PRP-T">
-				<concept code="48" displayName="Hib-PRP-T" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE44" displayName="HepB Dialysis" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepB Dialysis">
-				<concept code="44" displayName="HepB Dialysis" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE104" displayName="HepA-HepB (Twinrix)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepA-HepB (Twinrix)">
-				<concept code="104" displayName="HepA-HepB (Twinrix)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE153"
-				displayName="influenza, injectable, MDCK, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, injectable, MDCK, preservative free">
-				<concept code="153"
-					displayName="influenza, injectable, MDCK, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE83" displayName="HepA peds/adol 2 dose" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepA ped/adol 2 dose">
-				<concept code="83" displayName="HepA ped/adol 2 dose" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE126"
-				displayName="Novel influenza-H1N1-09, preservative-free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Novel influenza-H1N1-09, preservative-free">
-				<concept code="126" displayName="Novel influenza-H1N1-09, preservative-free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE152" displayName="Pneumococcal Conjugate NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate NOS">
-				<concept code="152" displayName="Pneumococcal Conjugate NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE158"
-				displayName="influenza, injectable, quadrivalent, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza-IIV4, IM (over 3yrs)">
-				<concept code="158" displayName="Influenza-IIV4, IM (over 3yrs)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE05" displayName="Measles" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Measles">
-				<concept code="05" displayName="Measles" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE15" displayName="Influenza, split" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, split">
-				<concept code="15" displayName="Influenza, split" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE03" displayName="MMR" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="MMR">
-				<concept code="03" displayName="MMR" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE51" displayName="Hib-HepB (Comvax)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Hib-HepB (Comvax)">
-				<concept code="51" displayName="Hib-HepB (Comvax)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE31" displayName="HepA pediatric NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepA pediatric NOS">
-				<concept code="31" displayName="HepA pediatric NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE144"
-				displayName="influenza, seasonal, intradermal, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, seasonal, intradermal, preservative free">
-				<concept code="144"
-					displayName="influenza, seasonal, intradermal, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE137" displayName="HPV NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HPV NOS">
-				<concept code="137" displayName="HPV NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE128"
-				displayName="Novel Influenza-H1N1-09, all formulations" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Novel Influenza-H1N1-09, all formulations">
-				<concept code="128" displayName="Novel Influenza-H1N1-09, all formulations" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE85" displayName="HepA NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepA NOS">
-				<concept code="85" displayName="HepA NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICEIVM201"
-				displayName="Immunization-vaccination management" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.5"
-				codeSystemName="SNOMED" displayName="Immunization/vaccination management (procedure)">
-				<concept code="384810002"
-					displayName="Immunization/vaccination management (procedure)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE125"
-				displayName="Novel Influenza-H1N1-09, nasal" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Novel Influenza-H1N1-09, nasal">
-				<concept code="125" displayName="Novel Influenza-H1N1-09, nasal" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE46" displayName="Hib-PRP-D (ProHIBIT)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Hib-PRP-D (ProHIBIT)">
-				<concept code="46" displayName="Hib-PRP-D (ProHIBIT)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE990" displayName="Disease Immunity Focus" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103"
-				codeSystemName="ICE3 Disease Immunity Focus" displayName="Hib">
-				<concept code="482.2" displayName="Hib" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE1011" displayName="Disease Immunity Focus" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103"
-				codeSystemName="ICE3 Disease Immunity Focus" displayName="Zoster">
-				<concept code="053.9" displayName="Zoster" />
-			</fromConcepts>
-		</conceptMapping>
-		<!-- 
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1" codeSystemName="OpenCDS concepts" code="ICE07989" displayName="Coronavirus (unspecified)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICD-9-CM">
-				<concept code="079.89" displayName="Coronavirus (unspecified)" />
-			</fromConcepts>
-		</conceptMapping>
-		-->
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE996"
-				displayName="Disease Immunity Focus (HepA)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
-				<concept code="070.1" displayName="Viral hepatitis A without mention of hepatic coma" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
-				<concept code="B15.9" displayName="Hepatitis A without hepatic coma applicable to Hepatitis A (acute)(viral) NOS" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
-				<concept code="278971009" displayName="Serology confirmed hepatitis A"/>
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1" codeSystemName="OpenCDS concepts" code="ICE994" displayName="Disease Immunity Focus (Mumps)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
-				<concept code="072.9" displayName="Mumps without mention of complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
-				<concept code="B26.9" displayName="Mumps without complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
-				<concept code="371112003" displayName="Serology confirmed mumps"/>
-			</fromConcepts>			
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE140"
-				displayName="influenza, seasonal, injectable, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, seasonal, injectable, preservative free">
-				<concept code="140"
-					displayName="influenza, seasonal, injectable, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="C30" displayName="Male" />
-			<fromConcepts codeSystem="2.16.840.1.113883.5.1"
-				codeSystemName="HL7 administrative gender" displayName="Male">
-				<concept code="M" displayName="Male" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE62" displayName="HPV Quadrivalent (Gardasil)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HPV Quadrivalent (Gardasil)">
-				<concept code="62" displayName="HPV Quadrivalent (Gardasil)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE89"
-				displayName="Polio, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Polio Unspecified forumulation">
-				<concept code="89" displayName="Polio Unspecified forumulation" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE998" displayName="Disease Immunity Documented" />
-			<fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.8"
-				codeSystemName="ICE3 Disease Immunity Source" displayName="Disease Documented">
-				<concept code="DISEASE_DOCUMENTED" displayName="Disease Documented" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE1000" displayName="Proof of Immunity" />
-			<fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.8"
-				codeSystemName="ICE3 Disease Immunity Source" displayName="Proof of Immunity">
-				<concept code="PROOF_OF_IMMUNITY" displayName="Proof of Immunity" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE74" displayName="Rotavirus" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus">
-				<concept code="74" displayName="Rotavirus" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE45" displayName="HepB NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepB NOS">
-				<concept code="45" displayName="HepB NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE189" displayName="Hep B, adjuvanted" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Hep B, adjuvanted">
-				<concept code="189" displayName="Hep B, adjuvanted" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE198" displayName="DTP-Hep B-Hib, Pentavalent"/>
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTP-Hep B-Hib, Pentavalent">
-				<concept code="198" displayName="Hep B, adjuvanted" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE220" displayName="HepB recombinant, 3-antigen, Al(OH)3" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepB recombinant, 3-antigen, Al(OH)3">
-				<concept code="220" displayName="HepB recombinant, 3-antigen, Al(OH)3" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE94" displayName="MMR-Varicella" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="MMR-Varicella">
-				<concept code="94" displayName="MMR-Varicella" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE50" displayName="DTaP-Hib (TriHiBit)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTaP-Hib (TriHiBit)">
-				<concept code="50" displayName="DTaP-Hib (TriHiBit)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE109" displayName="Pneumococcal Conjugate NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate NOS">
-				<concept code="109" displayName="Pneumococcal Conjugate NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE07" displayName="Mumps" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Mumps">
-				<concept code="07" displayName="Mumps" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE16" displayName="Influenza, whole" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, whole">
-				<concept code="16" displayName="Influenza, whole" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE21" displayName="Varicella" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Varicella">
-				<concept code="21" displayName="Varicella" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE33"
-				displayName="Pneumococcal Polysaccharide 23 Valent" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Polysaccharide 23 Valent">
-				<concept code="33" displayName="Pneumococcal Polysaccharide 23 Valent" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE155"
-				displayName="influenza, recombinant, injectable, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)"
-				displayName="nfluenza, recombinant, injectable, preservative free">
-				<concept code="155"
-					displayName="nfluenza, recombinant, injectable, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE136"
-				displayName="Meningococcal MCV4O (Menveo)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MCV4O (Menveo)">
-				<concept code="136" displayName="Meningococcal MCV4O (Menveo)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE130" displayName="DTaP/IPV" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTaP/IPV">
-				<concept code="130" displayName="DTaP/IPV" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE148"
-				displayName="Mening C&amp;Y-Hib PRP-T (Menhibrix)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal C/Y-HIB PRP (Menhibrix)">
-				<concept code="148" displayName="Meningococcal C/Y-HIB PRP (Menhibrix)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE223"
-				displayName="Immunization Recommended (Due Now)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.6"
-				codeSystemName="ICE3 Immunization Recommendation Reason"
-				displayName="Due Now">
-				<concept code="DUE_NOW" displayName="Due Now" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE110" displayName="DTaP-Hep B-IPV" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTaP-Hep B-IPV">
-				<concept code="110" displayName="DTaP-Hep B-IPV" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE38" displayName="Mumps/Rubella" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Mumps/Rubella">
-				<concept code="38" displayName="Mumps/Rubella" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE116"
-				displayName="Rotavirus RV5 (RotaTeq, 3 dose)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus RV5 (RotaTeq, 3 dose)">
-				<concept code="116" displayName="Rotavirus RV5 (RotaTeq, 3 dose)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE47" displayName="Hib-HbOC (HibTITER)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Hib-HbOC">
-				<concept code="47" displayName="Hib-HbOC" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE120" displayName="DTaP-Hib (PRP-T)-IPV" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DTaP-Hib (PRP-T)-IPV">
-				<concept code="120" displayName="DTaP-Hib (PRP-T)-IPV" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE120" displayName="DT-IPV adsorbed Non-US" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="DT-IPV adsorbed Non-US">
-				<concept code="195" displayName="DT-IPV adsorbed Non-US" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE991"
-				displayName="Disease Immunity Focus (Rotavirus)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103"
-				codeSystemName="ICE3 Disease Immunity Focus" displayName="Rotavirus">
-				<concept code="008.61" displayName="Rotavirus" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE151"
-				displayName="influenza nasal, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza nasal, unspecified formulation">
-				<concept code="151" displayName="influenza nasal, unspecified formulation" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="C31" displayName="Female" />
-			<fromConcepts codeSystem="2.16.840.1.113883.5.1"
-				codeSystemName="HL7 administrative gender" displayName="Female">
-				<concept code="F" displayName="Female" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE150"
-				displayName="influenza, injectable, quadrivalent, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)"
-				displayName="influenza, injectable, quadrivalent, preservative free">
-				<concept code="150"
-					displayName="influenza, injectable, quadrivalent, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE149"
-				displayName="influenza, live, intranasal, quadrivalent" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, live, intranasal, quadrivalent">
-				<concept code="149" displayName="influenza, live, intranasal, quadrivalent" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE52" displayName="HepA adult" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepA adult">
-				<concept code="52" displayName="HepA adult" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE02" displayName="OPV" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="OPV">
-				<concept code="02" displayName="OPV" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE178" displayName="OPV bivalent" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="OPV bivalent">
-				<concept code="178" displayName="OPV bivalent" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE179" displayName="OPV, monovalent, unspecified" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="OPV, monovalent, unspecified">
-				<concept code="179" displayName="OPV, monovalent, unspecified" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE182" displayName="OPV, Unspecified" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="OPV, Unspecified">
-				<concept code="182" displayName="OPV" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE185" displayName="influenza, recombinant, quadrivalent,injectable, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, recombinant, quadrivalent,injectable, preservative free">
-				<concept code="185" displayName="influenza, recombinant, quadrivalent,injectable, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE186" displayName="Influenza, injectable, MDCK, quadrivalent" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, injectable, MDCK, quadrivalent">
-				<concept code="186" displayName="Influenza, injectable, MDCK, quadrivalent" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE194" displayName="Influenza, Southern Hemisphere, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, unspecified formulation">
-				<concept code="194" displayName="Influenza, Southern Hemisphere, unspecified formulation" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE197" displayName="Influenza, high dose, quadrivalent" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, high dose, quadrivalent">
-				<concept code="197" displayName="Influenza, high dose, quadrivalent" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE200" displayName="Influenza, Southern Hemisphere, pediatric, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, pediatric, preservative free">
-				<concept code="200" displayName="Influenza, Southern Hemisphere, pediatric, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE201" displayName="Influenza, Southern Hemisphere, preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, preservative free">
-				<concept code="201" displayName="Influenza, Southern Hemisphere, preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE202" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative">
-				<concept code="202" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE205" displayName="Influenza, seasonal vaccine, quadrivalent, adjuvanted" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, seasonal vaccine, quadrivalent, adjuvanted">
-				<concept code="205" displayName="Influenza, seasonal vaccine, quadrivalent, adjuvanted" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE231" displayName="Influenza, Southern Hemisphere, high-dose, quadrivalent" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, high-dose, quadrivalent">
-				<concept code="231" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE162" displayName="Meningococcal B FHbp, recombinant (Trumenba)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal B FHbp, recombinant (Trumenba)">
-				<concept code="162" displayName="Meningococcal B FHbp, recombinant (Trumenba)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE163" displayName="Meningococcal B 4C, OMV (Bexsero)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal B 4C, OMV (Bexsero)">
-				<concept code="163" displayName="Meningococcal B 4C, OMV (Bexsero)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE111" displayName="influenza, live, intranasal" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, live, intranasal">
-				<concept code="111" displayName="influenza, live, intranasal" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE10" displayName="IPV" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="IPV">
-				<concept code="10" displayName="IPV" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE108"
-				displayName="Meningococcal, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal, unspecified formulation">
-				<concept code="108" displayName="Meningococcal, unspecified formulation" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE06" displayName="Rubella" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Rubella">
-				<concept code="06" displayName="Rubella" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE141"
-				displayName="influenza, seasonal, injectable" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="influenza, seasonal, injectable">
-				<concept code="141" displayName="influenza, seasonal, injectable" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE84"
-				displayName="HepA pediatric/adolescent (3 dose)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepA pediatric/adolescent (3 dose)">
-				<concept code="84" displayName="HepA pediatric/adolescent (3 dose)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE993"
-				displayName="Disease Immunity Focus (Rubella)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
-				<concept code="056.9" displayName="Rubella without mention of complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
-				<concept code="B06.9" displayName="Rubella without complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
-				<concept code="278968001" displayName="Serology confirmed rubella"/>
-			</fromConcepts>						
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE49" displayName="Hib-PRP-OMP (PedvaxHIB)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Hib-PRP-OMP (PedvaxHIB)">
-				<concept code="49" displayName="Hib-PRP-OMP (PedvaxHIB)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE32"
-				displayName="Meningococcal MPSV4 (Menomune) " />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MPSV4 (Menomune) ">
-				<concept code="32" displayName="Meningococcal MPSV4 (Menomune) " />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE147"
-				displayName="Meningococcal MCV4, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MCV4, unspecified formulation">
-				<concept code="147" displayName="Meningococcal MCV4, unspecified formulation" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE203"
-				displayName="Meningococcal MenACWY-TT (MenQuadfi)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MenACWY-TT (MenQuadfi)">
-				<concept code="203" displayName="Meningococcal MenACWY-TT (MenQuadfi)" />
-			</fromConcepts>
-		</conceptMapping>		
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE999" displayName="Disease Immunity Reason" />
-			<fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.9"
-				codeSystemName="ICE3 Disease Immunity Reason" displayName="Is Immune">
-				<concept code="IS_IMMUNE" displayName="Is Immune" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE997" displayName="Disease Immunity Focus" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
-				<concept code="070.30" displayName="Viral hepatitis B without mention of hepatic coma" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
-				<concept code="B19.10" displayName="Unspecified viral hepatitis B without hepatic coma applicable to unspecified viral hepatitis B NOS" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
-				<concept code="271511000" displayName="Serology confirmed hepatitis B"/>
-			</fromConcepts>			
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE42" displayName="HepB high risk infant" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="HepB high risk infant">
-				<concept code="42" displayName="HepB high risk infant" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE88"
-				displayName="Influenza, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Influenza, unspecified formulation">
-				<concept code="88" displayName="Influenza, unspecified formulation" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE992" displayName="Disease Immunity Focus" />
-			<fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
-				<concept code="052.9" displayName="Varicella without mention of complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
-				<concept code="B01.9" displayName="Varicella without complication" />
-			</fromConcepts>
-			<fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
-				<concept code="371113008" displayName="Serology confirmed varicella"/>
-				<concept code="38907003" displayName="History of Varicella infection"/>
-			</fromConcepts>			
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE127" displayName="Novel influenza-H1N1-09" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="127" displayName="Novel influenza-H1N1-09" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE01" displayName="DTP" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="01" displayName="DTP" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE09" displayName="Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed">
-				<concept code="09" displayName="Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE196" displayName="Td (adult) adsorbed, preservative free, Lf unspecified" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="Td (adult) adsorbed, preservative free, Lf unspecified">
-				<concept code="196" displayName="Td (adult) adsorbed, preservative free, Lf unspecified" />
-			</fromConcepts>
-		</conceptMapping>		
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE20" displayName="DTaP" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="20" displayName="DTaP" />
-			</fromConcepts>
-		</conceptMapping>		
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE28" displayName="DT" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="28" displayName="DT" />
-			</fromConcepts>
-		</conceptMapping>		
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE106" displayName="DTaP, 5 pertussis antigens" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="106" displayName="DTaP, 5 pertussis antigens" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE107" displayName="DTaP, unspecified formulation" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="107" displayName="DTaP, 5 pertussis antigens" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE113" displayName="Td (adult) preservative free" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="113" displayName="Td (adult) preservative free" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE115" displayName="Tdap" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="115" displayName="Tdap" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE138" displayName="Td (adult not absorbed)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="138" displayName="Td (adult not absorbed)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE139" displayName="Td (adult) NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="139" displayName="Td (adult) NOS" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE132" displayName="DTaP-IPV-Hib-Hep B, historical" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="132" displayName="DTaP-IPV-Hib-Hep B, historical" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE146" displayName="DTaP-IPV-Hib-Hep B" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="146" displayName="DTaP-IPV-Hib-Hep B" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE207" displayName="COVID-19, mRNA LNP-S, PF, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="207" displayName="COVID-19, mRNA LNP-S, PF, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE208" displayName="COVID-19, mRNA LNP-S, PF, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="208" displayName="COVID-19, mRNA LNP-S, PF, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE210" displayName="COVID-19, vector-nr,rS-ChadOx1, PF, 0.5 mL, AstraZeneca" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="210" displayName="COVID-19, vector-nr,rS-ChadOx1, PF, 0.5 mL, AstraZeneca" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE211" displayName="COVID-19, rS-nanoparticle, Novavax" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="211" displayName="COVID-19, rS-nanoparticle, Novavax" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE212" displayName="COVID-19, vector-nr, rS-Ad26, PF, 0.5 mL, Janssen" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="212" displayName="COVID-19, vector-nr, rS-Ad26, PF, 0.5 mL, Janssen" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE213" displayName="COVID-19, NOS" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="213" displayName="COVID-19 (NOS)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE217" displayName="COVID-19, mRNA, 12+ yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="217" displayName="COVID-19, mRNA, 12+ yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE218" displayName="COVID-19, mRNA, 5-11 yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="218" displayName="COVID-19, mRNA, 5-11 yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE219" displayName="COVID-19, mRNA, 6mos-4yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="219" displayName="COVID-19, mRNA, 6mos-4yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE221" displayName="COVID-19, mRNA, 6-11 yrs, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="221" displayName="COVID-19, mRNA, 6-11 yrs, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE227" displayName="COVID-19, mRNA, LNP-S, PF, pediatric 50 mcg/0.5 mL dose, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="227" displayName="COVID-19, mRNA, LNP-S, PF, pediatric 50 mcg/0.5 mL dose, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE228" displayName="COVID-19, mRNA, 6mos-&lt;6yr, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="228" displayName="COVID-19, mRNA, 6mos-&lt;6yr, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE229" displayName="COVID-19, mRNA booster, 6+ yrs, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="229" displayName="COVID-19, mRNA booster, 6+ yrs, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE230" displayName="COVID-19, mRNA, booster, 6 mos-5yrs, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="230" displayName="COVID-19, mRNA, booster, 6 mos-5yrs, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE300" displayName="COVID-19, mRNA booster, 12+ yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="300" displayName="COVID-19, mRNA booster, 12+ yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE301" displayName="COVID-19, mRNA booster, 5-11 yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="301" displayName="COVID-19, mRNA booster, 5-11 yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE302" displayName="COVID-19, mRNA, booster, 6 mos-4 yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="302" displayName="COVID-19, mRNA, booster, 6 mos-4 yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE500" displayName="COVID-19 Non-US, Product Unknown" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="500" displayName="COVID-19 Non-US, Product Unknown" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE501" displayName="COVID-19 IV Non-US (QAZCOVID-IN)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="501" displayName="COVID-19 IV Non-US (QAZCOVID-IN)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE502" displayName="COVID-19 IV Non-US (COVAXIN)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="502" displayName="COVID-19 IV Non-US (COVAXIN)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE503" displayName="COVID-19 LAV Non-US (COVIVAC)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="503" displayName="COVID-19 LAV Non-US (COVIVAC)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE504" displayName="COVID-19 VVnr Non-US (Sputnik Light)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="504" displayName="COVID-19 VVnr Non-US (Sputnik Light)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE505" displayName="COVID-19 VVnr Non-US (Sputnik V)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="505" displayName="COVID-19 VVnr Non-US (Sputnik V)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE506" displayName="COVID-19 VVnr Non-US Vaccine (CanSino Biological Inc./Beijing Institute of Biotechnology)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="506" displayName="COVID-19 VVnr Non-US Vaccine (CanSino Biological Inc./Beijing Institute of Biotechnology)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE507" displayName="COVID-19 vaccine, PS, non-US, Anhui Zhifei Longcom Biopharmaceutical, Chinese Academy of Sciences" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="507" displayName="COVID-19 vaccine, PS, non-US, Anhui Zhifei Longcom Biopharmaceutical, Chinese Academy of Sciences" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE508" displayName="COVID-19 PS Non-US (Jiangsu Province Centers for Disease Control and Prevention)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="508" displayName="COVID-19 PS Non-US (Jiangsu Province Centers for Disease Control and Prevention)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE509" displayName="COVID-19 PS Non-US (EpiVacCorona)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="509" displayName="COVID-19 PS Non-US (EpiVacCorona)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE510" displayName="COVID-19 IV Non-US (BIBP, Sinopharm)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="510" displayName="COVID-19 IV Non-US (BIBP, Sinopharm)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE511" displayName="COVID-19 IV Non-US (CoronaVac, Sinovac)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="511" displayName="COVID-19 IV Non-US (CoronaVac, Sinovac)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE512" displayName="COVID-19 VLP Non-US Vaccine (Medicago, Covifenz)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="512" displayName="COVID-19 VLP Non-US Vaccine (Medicago, Covifenz)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE513" displayName="COVID-19 PS Non-US Vaccine (Anhui Zhifei Longcom, Zifivax)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="513" displayName="COVID-19 PS Non-US Vaccine (Anhui Zhifei Longcom, Zifivax)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE514" displayName="COVID-19 DNA Non-US Vaccine (Zydus Cadila, ZyCoV-D)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="514" displayName="COVID-19 DNA Non-US Vaccine (Zydus Cadila, ZyCoV-D)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE515" displayName="COVID-19 PS Non-US Vaccine (Medigen, MVC-COV1901)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="515" displayName="COVID-19 PS Non-US Vaccine (Medigen, MVC-COV1901)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE516" displayName="COVID-19 Inactivated Non-US Vaccine (Minhai Biotechnology Co, KCONVAC)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="516" displayName="COVID-19 Inactivated Non-US Vaccine (Minhai Biotechnology Co, KCONVAC)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE517" displayName="COVID-19 PS Non-US Vaccine (Biological E Limited, Corbevax)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="517" displayName="COVID-19 PS Non-US Vaccine (Biological E Limited, Corbevax)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE518" displayName="COVID-19, Inactivated, Non-US (VLA2001, Valneva)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="518" displayName="COVID-19, Inactivated, Non-US (VLA2001, Valneva)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE520" displayName="COVID-19, mRNA bivalent, Non-US (Comirnaty Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="520" displayName="COVID-19, mRNA bivalent, Non-US (Comirnaty Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE521" displayName="COVID-19 SP, protein-based, adjuvanted (VidPrevtyn Beta), Sanofi-GSK" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="521" displayName="COVID-19 SP, protein-based, adjuvanted (VidPrevtyn Beta), Sanofi-GSK" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE75" displayName="Monkeypox Smallpox (ACAM2000)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="75" displayName="Monkeypox Smallpox (ACAM2000)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE105" displayName="Vaccinia (smallpox) vaccine, diluted" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="105" displayName="Vaccinia (smallpox) vaccine, diluted" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-				codeSystemName="OpenCDS concepts" code="ICE206" displayName="Monkeypox Smallpox (JYNNEOS), Vaccinia, live" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-				codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="206" displayName="Monkeypox Smallpox (JYNNEOS), Vaccinia, live" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE308" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-4 yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="308" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-4 yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE309" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="309" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE310" displayName="COVID-19, mRNA, 2023-2024 Formula, 5-11 yrs, Pfizer" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="310" displayName="COVID-19, mRNA, 2023-2024 Formula, 5-11 yrs, Pfizer" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE311" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-11 yrs, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="311" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-11 yrs, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE312" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Moderna" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="312" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Moderna" />
-			</fromConcepts>
-		</conceptMapping>
-		<conceptMapping>
-			<toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
-					   codeSystemName="OpenCDS concepts" code="ICE313" displayName="Novavax COVID-19 Vaccine, Adjuvanted" />
-			<fromConcepts codeSystem="2.16.840.1.113883.12.292"
-						  codeSystemName="Vaccines administered (CVX)" displayName="CVX">
-				<concept code="313" displayName="Novavax COVID-19 Vaccine, Adjuvanted" />
-			</fromConcepts>
-		</conceptMapping>
-		<timestamp>2022-08-15T00:00:00.606-05:00</timestamp>
-		<userId>daryl</userId>
-	</conceptDeterminationMethod>
+  xmlns:ns2="org.opencds.dss.config_rest.v1_0" xmlns:ns3="org.opencds.dss.config.v1_0">
+  <conceptDeterminationMethod code="C36"
+    displayName="Best available OpenCDS concept determination method"
+    codeSystem="2.16.840.1.113883.3.795.12.1.1" version="1.0">
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE17" displayName="Hib NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Hib NOS">
+        <concept code="17" displayName="Hib NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE04" displayName="Measles/Rubella"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Measles/Rubella">
+        <concept code="04" displayName="Measles/Rubella"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE121" displayName="Zoster vaccine, live"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Zoster vaccine, live">
+        <concept code="121" displayName="Zoster vaccine, live"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE187" displayName="Zoster recombinant"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Zoster recombinant">
+        <concept code="187" displayName="Zoster recombinant"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE188" displayName="Zoster, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Zoster, unspecified formulation">
+        <concept code="188" displayName="Zoster, unspecified formulation"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE122" displayName="Rotavirus NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus NOS">
+        <concept code="122" displayName="Rotavirus NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE100"
+        displayName="Pneumococcal Conjugate 7 valent (PCV 7)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate 7 valent (PCV 7)">
+        <concept code="100" displayName="Pneumococcal Conjugate 7 valent (PCV 7)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE995"
+        displayName="Disease Immunity Focus (Measles)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
+        <concept code="055.9" displayName="Measles without mention of complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
+        <concept code="B05.9" displayName="Measles without complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
+        <concept code="371111005" displayName="Serology confirmed measles"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE102" displayName="DTP-Hib-HepB"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTP-Hib-HepB">
+        <concept code="102" displayName="DTP-Hib-HepB"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE133" displayName="Pneumococcal Conjugate NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate 13 valent (PCV 13)">
+        <concept code="133" displayName="Pneumococcal Conjugate 13 valent (PCV 13)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE215" displayName="Pneumococcal conjugate PCV15"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal conjugate PCV15">
+        <concept code="215" displayName="Pneumococcal conjugate PCV15"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE216" displayName="Pneumococcal conjugate PCV20"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal conjugate PCV20">
+        <concept code="216" displayName="Pneumococcal conjugate PCV20"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE43" displayName="HepB adult &gt;= 20yrs"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepB adult &gt;= 20yrs">
+        <concept code="43" displayName="HepB adult &gt;= 20yrs"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE114"
+        displayName="Meningococcal MCV4P (Menactra)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MCV4P (Menactra)">
+        <concept code="114" displayName="Meningococcal MCV4P (Menactra)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE08" displayName="HepB peds &lt;20yrs"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepB peds &lt; 20yrs">
+        <concept code="08" displayName="HepB peds &lt; 20yrs"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE135"
+        displayName="influenza, high dose, seasonal"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, high dose, seasonal">
+        <concept code="135" displayName="influenza, high dose, seasonal"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE22"
+        displayName="DTP-Hib (Tetramune; OmniHib-DTP)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTP-Hib (Tetramune; OmniHib-DTP)">
+        <concept code="22" displayName="DTP-Hib (Tetramune; OmniHib-DTP)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE119"
+        displayName="Rotavirus RV1 (Rotarix, 2 dose)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus RV1 (Rotarix, 2 dose)">
+        <concept code="119" displayName="Rotavirus RV1 (Rotarix, 2 dose)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE161"
+        displayName="influenza, injectable, quadrivalent, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)"
+        displayName="Influenza, injectable, quadrivalent, preservative free, pediatric">
+        <concept code="161"
+          displayName="Influenza, injectable, quadrivalent, preservative free, pediatric"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE166"
+        displayName="influenza, injectable, quadrivalent, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)"
+        displayName="Influenza, injectable, quadrivalent, preservative free, pediatric">
+        <concept code="166"
+          displayName="Influenza, intradermal, quadrivalent, preservative free, injectable"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE168"
+        displayName="Seasonal trivalent influenza vaccine, adjuvanted, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)"
+        displayName="Seasonal trivalent influenza vaccine, adjuvanted, preservative free ">
+        <concept code="168"
+          displayName="Seasonal trivalent influenza vaccine, adjuvanted, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE170" displayName="DTaP-IPV-Hib"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTaP-IPV-Hib">
+        <concept code="170" displayName="DTaP-IPV-Hib"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE171" displayName="Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent">
+        <concept code="171" displayName="Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE320"
+        displayName="influenza, injectable, MDCK, preservative"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)"
+        displayName="influenza, injectable, MDCK, preservative">
+        <concept code="320"
+          displayName="influenza, injectable, MDCK, preservative"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE118" displayName="HPV Bivalent (Cervarix)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HPV Bivalent (Cervarix)">
+        <concept code="118" displayName="HPV Bivalent (Cervarix)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE165" displayName="HPV9"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="165" displayName="HPV9"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE48" displayName="Hib-PRP-T (ActHIB, Hiberix)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Hib-PRP-T">
+        <concept code="48" displayName="Hib-PRP-T"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE44" displayName="HepB Dialysis"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepB Dialysis">
+        <concept code="44" displayName="HepB Dialysis"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE104" displayName="HepA-HepB (Twinrix)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepA-HepB (Twinrix)">
+        <concept code="104" displayName="HepA-HepB (Twinrix)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE153"
+        displayName="influenza, injectable, MDCK, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, injectable, MDCK, preservative free">
+        <concept code="153"
+          displayName="influenza, injectable, MDCK, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE83" displayName="HepA peds/adol 2 dose"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepA ped/adol 2 dose">
+        <concept code="83" displayName="HepA ped/adol 2 dose"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE126"
+        displayName="Novel influenza-H1N1-09, preservative-free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Novel influenza-H1N1-09, preservative-free">
+        <concept code="126" displayName="Novel influenza-H1N1-09, preservative-free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE152" displayName="Pneumococcal Conjugate NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate NOS">
+        <concept code="152" displayName="Pneumococcal Conjugate NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE158"
+        displayName="influenza, injectable, quadrivalent, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza-IIV4, IM (over 3yrs)">
+        <concept code="158" displayName="Influenza-IIV4, IM (over 3yrs)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE05" displayName="Measles"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Measles">
+        <concept code="05" displayName="Measles"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE15" displayName="Influenza, split"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, split">
+        <concept code="15" displayName="Influenza, split"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE03" displayName="MMR"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="MMR">
+        <concept code="03" displayName="MMR"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE51" displayName="Hib-HepB (Comvax)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Hib-HepB (Comvax)">
+        <concept code="51" displayName="Hib-HepB (Comvax)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE31" displayName="HepA pediatric NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepA pediatric NOS">
+        <concept code="31" displayName="HepA pediatric NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE144"
+        displayName="influenza, seasonal, intradermal, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, seasonal, intradermal, preservative free">
+        <concept code="144"
+          displayName="influenza, seasonal, intradermal, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE137" displayName="HPV NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HPV NOS">
+        <concept code="137" displayName="HPV NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE128"
+        displayName="Novel Influenza-H1N1-09, all formulations"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Novel Influenza-H1N1-09, all formulations">
+        <concept code="128" displayName="Novel Influenza-H1N1-09, all formulations"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE85" displayName="HepA NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepA NOS">
+        <concept code="85" displayName="HepA NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICEIVM201"
+        displayName="Immunization-vaccination management"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.5"
+        codeSystemName="SNOMED" displayName="Immunization/vaccination management (procedure)">
+        <concept code="384810002"
+          displayName="Immunization/vaccination management (procedure)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE125"
+        displayName="Novel Influenza-H1N1-09, nasal"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Novel Influenza-H1N1-09, nasal">
+        <concept code="125" displayName="Novel Influenza-H1N1-09, nasal"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE46" displayName="Hib-PRP-D (ProHIBIT)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Hib-PRP-D (ProHIBIT)">
+        <concept code="46" displayName="Hib-PRP-D (ProHIBIT)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE990" displayName="Disease Immunity Focus"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103"
+        codeSystemName="ICE3 Disease Immunity Focus" displayName="Hib">
+        <concept code="482.2" displayName="Hib"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE1011" displayName="Disease Immunity Focus"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103"
+        codeSystemName="ICE3 Disease Immunity Focus" displayName="Zoster">
+        <concept code="053.9" displayName="Zoster"/>
+      </fromConcepts>
+    </conceptMapping>
+    <!--
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1" codeSystemName="OpenCDS concepts" code="ICE07989" displayName="Coronavirus (unspecified)" />
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICD-9-CM">
+        <concept code="079.89" displayName="Coronavirus (unspecified)" />
+      </fromConcepts>
+    </conceptMapping>
+    -->
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE996"
+        displayName="Disease Immunity Focus (HepA)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
+        <concept code="070.1" displayName="Viral hepatitis A without mention of hepatic coma"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
+        <concept code="B15.9" displayName="Hepatitis A without hepatic coma applicable to Hepatitis A (acute)(viral) NOS"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
+        <concept code="278971009" displayName="Serology confirmed hepatitis A"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1" codeSystemName="OpenCDS concepts" code="ICE994" displayName="Disease Immunity Focus (Mumps)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
+        <concept code="072.9" displayName="Mumps without mention of complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
+        <concept code="B26.9" displayName="Mumps without complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
+        <concept code="371112003" displayName="Serology confirmed mumps"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE140"
+        displayName="influenza, seasonal, injectable, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, seasonal, injectable, preservative free">
+        <concept code="140"
+          displayName="influenza, seasonal, injectable, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="C30" displayName="Male"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.5.1"
+        codeSystemName="HL7 administrative gender" displayName="Male">
+        <concept code="M" displayName="Male"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE62" displayName="HPV Quadrivalent (Gardasil)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HPV Quadrivalent (Gardasil)">
+        <concept code="62" displayName="HPV Quadrivalent (Gardasil)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE89"
+        displayName="Polio, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Polio Unspecified forumulation">
+        <concept code="89" displayName="Polio Unspecified forumulation"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE998" displayName="Disease Immunity Documented"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.8"
+        codeSystemName="ICE3 Disease Immunity Source" displayName="Disease Documented">
+        <concept code="DISEASE_DOCUMENTED" displayName="Disease Documented"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE1000" displayName="Proof of Immunity"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.8"
+        codeSystemName="ICE3 Disease Immunity Source" displayName="Proof of Immunity">
+        <concept code="PROOF_OF_IMMUNITY" displayName="Proof of Immunity"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE74" displayName="Rotavirus"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus">
+        <concept code="74" displayName="Rotavirus"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE45" displayName="HepB NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepB NOS">
+        <concept code="45" displayName="HepB NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE189" displayName="Hep B, adjuvanted"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Hep B, adjuvanted">
+        <concept code="189" displayName="Hep B, adjuvanted"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE198" displayName="DTP-Hep B-Hib, Pentavalent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTP-Hep B-Hib, Pentavalent">
+        <concept code="198" displayName="Hep B, adjuvanted"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE220" displayName="HepB recombinant, 3-antigen, Al(OH)3"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepB recombinant, 3-antigen, Al(OH)3">
+        <concept code="220" displayName="HepB recombinant, 3-antigen, Al(OH)3"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE94" displayName="MMR-Varicella"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="MMR-Varicella">
+        <concept code="94" displayName="MMR-Varicella"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE50" displayName="DTaP-Hib (TriHiBit)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTaP-Hib (TriHiBit)">
+        <concept code="50" displayName="DTaP-Hib (TriHiBit)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE109" displayName="Pneumococcal Conjugate NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Conjugate NOS">
+        <concept code="109" displayName="Pneumococcal Conjugate NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE07" displayName="Mumps"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Mumps">
+        <concept code="07" displayName="Mumps"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE16" displayName="Influenza, whole"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, whole">
+        <concept code="16" displayName="Influenza, whole"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE21" displayName="Varicella"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Varicella">
+        <concept code="21" displayName="Varicella"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE33"
+        displayName="Pneumococcal Polysaccharide 23 Valent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Pneumococcal Polysaccharide 23 Valent">
+        <concept code="33" displayName="Pneumococcal Polysaccharide 23 Valent"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE155"
+        displayName="influenza, recombinant, injectable, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)"
+        displayName="nfluenza, recombinant, injectable, preservative free">
+        <concept code="155"
+          displayName="nfluenza, recombinant, injectable, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE136"
+        displayName="Meningococcal MCV4O (Menveo)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MCV4O (Menveo)">
+        <concept code="136" displayName="Meningococcal MCV4O (Menveo)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE130" displayName="DTaP/IPV"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTaP/IPV">
+        <concept code="130" displayName="DTaP/IPV"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE148"
+        displayName="Mening C&amp;Y-Hib PRP-T (Menhibrix)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal C/Y-HIB PRP (Menhibrix)">
+        <concept code="148" displayName="Meningococcal C/Y-HIB PRP (Menhibrix)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE223"
+        displayName="Immunization Recommended (Due Now)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.6"
+        codeSystemName="ICE3 Immunization Recommendation Reason"
+        displayName="Due Now">
+        <concept code="DUE_NOW" displayName="Due Now"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE110" displayName="DTaP-Hep B-IPV"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTaP-Hep B-IPV">
+        <concept code="110" displayName="DTaP-Hep B-IPV"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE38" displayName="Mumps/Rubella"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Mumps/Rubella">
+        <concept code="38" displayName="Mumps/Rubella"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE116"
+        displayName="Rotavirus RV5 (RotaTeq, 3 dose)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Rotavirus RV5 (RotaTeq, 3 dose)">
+        <concept code="116" displayName="Rotavirus RV5 (RotaTeq, 3 dose)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE47" displayName="Hib-HbOC (HibTITER)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Hib-HbOC">
+        <concept code="47" displayName="Hib-HbOC"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE120" displayName="DTaP-Hib (PRP-T)-IPV"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DTaP-Hib (PRP-T)-IPV">
+        <concept code="120" displayName="DTaP-Hib (PRP-T)-IPV"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE120" displayName="DT-IPV adsorbed Non-US"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="DT-IPV adsorbed Non-US">
+        <concept code="195" displayName="DT-IPV adsorbed Non-US"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE991"
+        displayName="Disease Immunity Focus (Rotavirus)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103"
+        codeSystemName="ICE3 Disease Immunity Focus" displayName="Rotavirus">
+        <concept code="008.61" displayName="Rotavirus"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE151"
+        displayName="influenza nasal, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza nasal, unspecified formulation">
+        <concept code="151" displayName="influenza nasal, unspecified formulation"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="C31" displayName="Female"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.5.1"
+        codeSystemName="HL7 administrative gender" displayName="Female">
+        <concept code="F" displayName="Female"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE150"
+        displayName="influenza, injectable, quadrivalent, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)"
+        displayName="influenza, injectable, quadrivalent, preservative free">
+        <concept code="150"
+          displayName="influenza, injectable, quadrivalent, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE149"
+        displayName="influenza, live, intranasal, quadrivalent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, live, intranasal, quadrivalent">
+        <concept code="149" displayName="influenza, live, intranasal, quadrivalent"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE52" displayName="HepA adult"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepA adult">
+        <concept code="52" displayName="HepA adult"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE02" displayName="OPV"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="OPV">
+        <concept code="02" displayName="OPV"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE178" displayName="OPV bivalent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="OPV bivalent">
+        <concept code="178" displayName="OPV bivalent"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE179" displayName="OPV, monovalent, unspecified"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="OPV, monovalent, unspecified">
+        <concept code="179" displayName="OPV, monovalent, unspecified"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE182" displayName="OPV, Unspecified"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="OPV, Unspecified">
+        <concept code="182" displayName="OPV"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE185" displayName="influenza, recombinant, quadrivalent,injectable, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, recombinant, quadrivalent,injectable, preservative free">
+        <concept code="185" displayName="influenza, recombinant, quadrivalent,injectable, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE186" displayName="Influenza, injectable, MDCK, quadrivalent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, injectable, MDCK, quadrivalent">
+        <concept code="186" displayName="Influenza, injectable, MDCK, quadrivalent"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE194" displayName="Influenza, Southern Hemisphere, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, unspecified formulation">
+        <concept code="194" displayName="Influenza, Southern Hemisphere, unspecified formulation"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE197" displayName="Influenza, high dose, quadrivalent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, high dose, quadrivalent">
+        <concept code="197" displayName="Influenza, high dose, quadrivalent"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE200" displayName="Influenza, Southern Hemisphere, pediatric, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, pediatric, preservative free">
+        <concept code="200" displayName="Influenza, Southern Hemisphere, pediatric, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE201" displayName="Influenza, Southern Hemisphere, preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, preservative free">
+        <concept code="201" displayName="Influenza, Southern Hemisphere, preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE202" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative">
+        <concept code="202" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE205" displayName="Influenza, seasonal vaccine, quadrivalent, adjuvanted"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, seasonal vaccine, quadrivalent, adjuvanted">
+        <concept code="205" displayName="Influenza, seasonal vaccine, quadrivalent, adjuvanted"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE231" displayName="Influenza, Southern Hemisphere, high-dose, quadrivalent"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, Southern Hemisphere, high-dose, quadrivalent">
+        <concept code="231" displayName="Influenza, Southern Hemisphere, quadrivalent, with preservative"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE162" displayName="Meningococcal B FHbp, recombinant (Trumenba)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal B FHbp, recombinant (Trumenba)">
+        <concept code="162" displayName="Meningococcal B FHbp, recombinant (Trumenba)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE163" displayName="Meningococcal B 4C, OMV (Bexsero)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal B 4C, OMV (Bexsero)">
+        <concept code="163" displayName="Meningococcal B 4C, OMV (Bexsero)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE111" displayName="influenza, live, intranasal"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, live, intranasal">
+        <concept code="111" displayName="influenza, live, intranasal"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE10" displayName="IPV"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="IPV">
+        <concept code="10" displayName="IPV"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE108"
+        displayName="Meningococcal, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal, unspecified formulation">
+        <concept code="108" displayName="Meningococcal, unspecified formulation"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE06" displayName="Rubella"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Rubella">
+        <concept code="06" displayName="Rubella"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE141"
+        displayName="influenza, seasonal, injectable"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="influenza, seasonal, injectable">
+        <concept code="141" displayName="influenza, seasonal, injectable"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE84"
+        displayName="HepA pediatric/adolescent (3 dose)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepA pediatric/adolescent (3 dose)">
+        <concept code="84" displayName="HepA pediatric/adolescent (3 dose)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE993"
+        displayName="Disease Immunity Focus (Rubella)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
+        <concept code="056.9" displayName="Rubella without mention of complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
+        <concept code="B06.9" displayName="Rubella without complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
+        <concept code="278968001" displayName="Serology confirmed rubella"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE49" displayName="Hib-PRP-OMP (PedvaxHIB)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Hib-PRP-OMP (PedvaxHIB)">
+        <concept code="49" displayName="Hib-PRP-OMP (PedvaxHIB)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE32"
+        displayName="Meningococcal MPSV4 (Menomune) "/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MPSV4 (Menomune) ">
+        <concept code="32" displayName="Meningococcal MPSV4 (Menomune) "/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE147"
+        displayName="Meningococcal MCV4, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MCV4, unspecified formulation">
+        <concept code="147" displayName="Meningococcal MCV4, unspecified formulation"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE203"
+        displayName="Meningococcal MenACWY-TT (MenQuadfi)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Meningococcal MenACWY-TT (MenQuadfi)">
+        <concept code="203" displayName="Meningococcal MenACWY-TT (MenQuadfi)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE999" displayName="Disease Immunity Reason"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.3.795.12.100.9"
+        codeSystemName="ICE3 Disease Immunity Reason" displayName="Is Immune">
+        <concept code="IS_IMMUNE" displayName="Is Immune"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE997" displayName="Disease Immunity Focus"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
+        <concept code="070.30" displayName="Viral hepatitis B without mention of hepatic coma"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
+        <concept code="B19.10" displayName="Unspecified viral hepatitis B without hepatic coma applicable to unspecified viral hepatitis B NOS"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
+        <concept code="271511000" displayName="Serology confirmed hepatitis B"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE42" displayName="HepB high risk infant"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="HepB high risk infant">
+        <concept code="42" displayName="HepB high risk infant"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE88"
+        displayName="Influenza, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Influenza, unspecified formulation">
+        <concept code="88" displayName="Influenza, unspecified formulation"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE992" displayName="Disease Immunity Focus"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD-9-CM" displayName="ICE3 Disease Immunity Focus (ICD-9-CM)">
+        <concept code="052.9" displayName="Varicella without mention of complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.90" codeSystemName="ICD-10-CM" displayName="ICE Disease Immunity Focus (ICD-10-CM)">
+        <concept code="B01.9" displayName="Varicella without complication"/>
+      </fromConcepts>
+      <fromConcepts codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="ICE Disease Immunity Focus (SNOMED-CT)">
+        <concept code="371113008" displayName="Serology confirmed varicella"/>
+        <concept code="38907003" displayName="History of Varicella infection"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE127" displayName="Novel influenza-H1N1-09"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="127" displayName="Novel influenza-H1N1-09"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE01" displayName="DTP"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="01" displayName="DTP"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE09" displayName="Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed">
+        <concept code="09" displayName="Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE196" displayName="Td (adult) adsorbed, preservative free, Lf unspecified"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="Td (adult) adsorbed, preservative free, Lf unspecified">
+        <concept code="196" displayName="Td (adult) adsorbed, preservative free, Lf unspecified"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE20" displayName="DTaP"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="20" displayName="DTaP"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE28" displayName="DT"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="28" displayName="DT"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE106" displayName="DTaP, 5 pertussis antigens"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="106" displayName="DTaP, 5 pertussis antigens"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE107" displayName="DTaP, unspecified formulation"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="107" displayName="DTaP, 5 pertussis antigens"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE113" displayName="Td (adult) preservative free"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="113" displayName="Td (adult) preservative free"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE115" displayName="Tdap"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="115" displayName="Tdap"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE138" displayName="Td (adult not absorbed)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="138" displayName="Td (adult not absorbed)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE139" displayName="Td (adult) NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="139" displayName="Td (adult) NOS"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE132" displayName="DTaP-IPV-Hib-Hep B, historical"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="132" displayName="DTaP-IPV-Hib-Hep B, historical"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE146" displayName="DTaP-IPV-Hib-Hep B"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="146" displayName="DTaP-IPV-Hib-Hep B"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE207" displayName="COVID-19, mRNA LNP-S, PF, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="207" displayName="COVID-19, mRNA LNP-S, PF, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE208" displayName="COVID-19, mRNA LNP-S, PF, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="208" displayName="COVID-19, mRNA LNP-S, PF, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE210" displayName="COVID-19, vector-nr,rS-ChadOx1, PF, 0.5 mL, AstraZeneca"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="210" displayName="COVID-19, vector-nr,rS-ChadOx1, PF, 0.5 mL, AstraZeneca"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE211" displayName="COVID-19, rS-nanoparticle, Novavax"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="211" displayName="COVID-19, rS-nanoparticle, Novavax"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE212" displayName="COVID-19, vector-nr, rS-Ad26, PF, 0.5 mL, Janssen"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="212" displayName="COVID-19, vector-nr, rS-Ad26, PF, 0.5 mL, Janssen"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE213" displayName="COVID-19, NOS"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="213" displayName="COVID-19 (NOS)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE217" displayName="COVID-19, mRNA, 12+ yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="217" displayName="COVID-19, mRNA, 12+ yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE218" displayName="COVID-19, mRNA, 5-11 yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="218" displayName="COVID-19, mRNA, 5-11 yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE219" displayName="COVID-19, mRNA, 6mos-4yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="219" displayName="COVID-19, mRNA, 6mos-4yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE221" displayName="COVID-19, mRNA, 6-11 yrs, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="221" displayName="COVID-19, mRNA, 6-11 yrs, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE227" displayName="COVID-19, mRNA, LNP-S, PF, pediatric 50 mcg/0.5 mL dose, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="227" displayName="COVID-19, mRNA, LNP-S, PF, pediatric 50 mcg/0.5 mL dose, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE228" displayName="COVID-19, mRNA, 6mos-&lt;6yr, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="228" displayName="COVID-19, mRNA, 6mos-&lt;6yr, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE229" displayName="COVID-19, mRNA booster, 6+ yrs, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="229" displayName="COVID-19, mRNA booster, 6+ yrs, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE230" displayName="COVID-19, mRNA, booster, 6 mos-5yrs, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="230" displayName="COVID-19, mRNA, booster, 6 mos-5yrs, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE300" displayName="COVID-19, mRNA booster, 12+ yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="300" displayName="COVID-19, mRNA booster, 12+ yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE301" displayName="COVID-19, mRNA booster, 5-11 yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="301" displayName="COVID-19, mRNA booster, 5-11 yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE302" displayName="COVID-19, mRNA, booster, 6 mos-4 yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="302" displayName="COVID-19, mRNA, booster, 6 mos-4 yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE500" displayName="COVID-19 Non-US, Product Unknown"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="500" displayName="COVID-19 Non-US, Product Unknown"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE501" displayName="COVID-19 IV Non-US (QAZCOVID-IN)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="501" displayName="COVID-19 IV Non-US (QAZCOVID-IN)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE502" displayName="COVID-19 IV Non-US (COVAXIN)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="502" displayName="COVID-19 IV Non-US (COVAXIN)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE503" displayName="COVID-19 LAV Non-US (COVIVAC)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="503" displayName="COVID-19 LAV Non-US (COVIVAC)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE504" displayName="COVID-19 VVnr Non-US (Sputnik Light)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="504" displayName="COVID-19 VVnr Non-US (Sputnik Light)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE505" displayName="COVID-19 VVnr Non-US (Sputnik V)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="505" displayName="COVID-19 VVnr Non-US (Sputnik V)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE506" displayName="COVID-19 VVnr Non-US Vaccine (CanSino Biological Inc./Beijing Institute of Biotechnology)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="506" displayName="COVID-19 VVnr Non-US Vaccine (CanSino Biological Inc./Beijing Institute of Biotechnology)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE507" displayName="COVID-19 vaccine, PS, non-US, Anhui Zhifei Longcom Biopharmaceutical, Chinese Academy of Sciences"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="507" displayName="COVID-19 vaccine, PS, non-US, Anhui Zhifei Longcom Biopharmaceutical, Chinese Academy of Sciences"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE508" displayName="COVID-19 PS Non-US (Jiangsu Province Centers for Disease Control and Prevention)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="508" displayName="COVID-19 PS Non-US (Jiangsu Province Centers for Disease Control and Prevention)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE509" displayName="COVID-19 PS Non-US (EpiVacCorona)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="509" displayName="COVID-19 PS Non-US (EpiVacCorona)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE510" displayName="COVID-19 IV Non-US (BIBP, Sinopharm)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="510" displayName="COVID-19 IV Non-US (BIBP, Sinopharm)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE511" displayName="COVID-19 IV Non-US (CoronaVac, Sinovac)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="511" displayName="COVID-19 IV Non-US (CoronaVac, Sinovac)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE512" displayName="COVID-19 VLP Non-US Vaccine (Medicago, Covifenz)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="512" displayName="COVID-19 VLP Non-US Vaccine (Medicago, Covifenz)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE513" displayName="COVID-19 PS Non-US Vaccine (Anhui Zhifei Longcom, Zifivax)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="513" displayName="COVID-19 PS Non-US Vaccine (Anhui Zhifei Longcom, Zifivax)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE514" displayName="COVID-19 DNA Non-US Vaccine (Zydus Cadila, ZyCoV-D)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="514" displayName="COVID-19 DNA Non-US Vaccine (Zydus Cadila, ZyCoV-D)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE515" displayName="COVID-19 PS Non-US Vaccine (Medigen, MVC-COV1901)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="515" displayName="COVID-19 PS Non-US Vaccine (Medigen, MVC-COV1901)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE516" displayName="COVID-19 Inactivated Non-US Vaccine (Minhai Biotechnology Co, KCONVAC)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="516" displayName="COVID-19 Inactivated Non-US Vaccine (Minhai Biotechnology Co, KCONVAC)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE517" displayName="COVID-19 PS Non-US Vaccine (Biological E Limited, Corbevax)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="517" displayName="COVID-19 PS Non-US Vaccine (Biological E Limited, Corbevax)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE518" displayName="COVID-19, Inactivated, Non-US (VLA2001, Valneva)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="518" displayName="COVID-19, Inactivated, Non-US (VLA2001, Valneva)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE520" displayName="COVID-19, mRNA bivalent, Non-US (Comirnaty Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="520" displayName="COVID-19, mRNA bivalent, Non-US (Comirnaty Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE521" displayName="COVID-19 SP, protein-based, adjuvanted (VidPrevtyn Beta), Sanofi-GSK"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="521" displayName="COVID-19 SP, protein-based, adjuvanted (VidPrevtyn Beta), Sanofi-GSK"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE75" displayName="Monkeypox Smallpox (ACAM2000)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="75" displayName="Monkeypox Smallpox (ACAM2000)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE105" displayName="Vaccinia (smallpox) vaccine, diluted"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="105" displayName="Vaccinia (smallpox) vaccine, diluted"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE206" displayName="Monkeypox Smallpox (JYNNEOS), Vaccinia, live"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="206" displayName="Monkeypox Smallpox (JYNNEOS), Vaccinia, live"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="519" displayName="COVID-19, mRNA bivalent, Non-US (Spikevax Bivalent)"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE308" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-4 yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="308" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-4 yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE309" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="309" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE310" displayName="COVID-19, mRNA, 2023-2024 Formula, 5-11 yrs, Pfizer"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="310" displayName="COVID-19, mRNA, 2023-2024 Formula, 5-11 yrs, Pfizer"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE311" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-11 yrs, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="311" displayName="COVID-19, mRNA, 2023-2024 Formula, 6 mos-11 yrs, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE312" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Moderna"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="312" displayName="COVID-19, mRNA, 2023-2024 Formula, 12+ yrs, Moderna"/>
+      </fromConcepts>
+    </conceptMapping>
+    <conceptMapping>
+      <toConcept codeSystem="2.16.840.1.113883.3.795.12.1.1"
+        codeSystemName="OpenCDS concepts" code="ICE313" displayName="Novavax COVID-19 Vaccine, Adjuvanted"/>
+      <fromConcepts codeSystem="2.16.840.1.113883.12.292"
+        codeSystemName="Vaccines administered (CVX)" displayName="CVX">
+        <concept code="313" displayName="Novavax COVID-19 Vaccine, Adjuvanted"/>
+      </fromConcepts>
+    </conceptMapping>
+    <timestamp>2022-08-15T00:00:00.606-05:00</timestamp>
+    <userId>daryl</userId>
+  </conceptDeterminationMethod>
 </ns2:conceptDeterminationMethods>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/OtherLists/supportedVaccines.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/OtherLists/supportedVaccines.xml
@@ -335,6 +335,14 @@
     		<displayName>Influenza, seasonal trivalent, adjuvanted, preservative free</displayName>
     	</cdsListItemConceptMapping>
     </cdsListItem>
+		<cdsListItem>
+			<cdsListItemKey>320</cdsListItemKey>
+			<cdsListItemValue>Influenza, injectable, MDCK, preservative</cdsListItemValue>
+			<cdsListItemConceptMapping>
+				<code>ICE320</code>
+				<displayName>Influenza, injectable, MDCK, preservative</displayName>
+			</cdsListItemConceptMapping>
+		</cdsListItem>
     <cdsListItem>
     	<cdsListItemKey>170</cdsListItemKey>
     	<cdsListItemValue>DTaP-IPV-Hib</cdsListItemValue>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/OtherLists/supportedVaccines.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/OtherLists/supportedVaccines.xml
@@ -337,10 +337,10 @@
     </cdsListItem>
 		<cdsListItem>
 			<cdsListItemKey>320</cdsListItemKey>
-			<cdsListItemValue>Influenza, injectable, MDCK, preservative</cdsListItemValue>
+			<cdsListItemValue>Influenza, MDCK, trivalent, preservative</cdsListItemValue>
 			<cdsListItemConceptMapping>
 				<code>ICE320</code>
-				<displayName>Influenza, injectable, MDCK, preservative</displayName>
+				<displayName>Influenza, MDCK, trivalent, preservative</displayName>
 			</cdsListItemConceptMapping>
 		</cdsListItem>
     <cdsListItem>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza1DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza1DoseSeries.xml
@@ -122,6 +122,10 @@
             <ns2:preferred>false</ns2:preferred>
             <ns2:vaccine code="231" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="influenza, Southern Hemisphere, high-dose, quadrivalent"/>
         </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
+        </ns2:doseVaccine>
     </ns2:iceSeriesDose>
     <ns2:seasonCode>20122013InfluenzaSeason</ns2:seasonCode>
     <ns2:seasonCode>20132014InfluenzaSeason</ns2:seasonCode>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza1DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza1DoseSeries.xml
@@ -124,7 +124,7 @@
         </ns2:doseVaccine>
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, MDCK, trivalent, preservative"/>
         </ns2:doseVaccine>
     </ns2:iceSeriesDose>
     <ns2:seasonCode>20122013InfluenzaSeason</ns2:seasonCode>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseDefaultSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseDefaultSeries.xml
@@ -77,7 +77,7 @@
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
             <ns2:vaccine code="161" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, quadrivalent, preservative free, pediatric"/>
-        </ns2:doseVaccine>        
+        </ns2:doseVaccine>
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
             <ns2:vaccine code="166" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, intradermal, quadrivalent, preservative free, injectable"/>
@@ -121,6 +121,10 @@
         <ns2:doseVaccine>
             <ns2:preferred>false</ns2:preferred>
             <ns2:vaccine code="231" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="influenza, Southern Hemisphere, high-dose, quadrivalent"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
         </ns2:doseVaccine>
     </ns2:iceSeriesDose>
     <ns2:iceSeriesDose>
@@ -184,7 +188,7 @@
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
             <ns2:vaccine code="161" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, quadrivalent, preservative free, pediatric"/>
-        </ns2:doseVaccine>        
+        </ns2:doseVaccine>
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
             <ns2:vaccine code="166" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, intradermal, quadrivalent, preservative free, injectable"/>
@@ -228,6 +232,10 @@
         <ns2:doseVaccine>
             <ns2:preferred>false</ns2:preferred>
             <ns2:vaccine code="231" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="influenza, Southern Hemisphere, high-dose, quadrivalent"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
         </ns2:doseVaccine>
 	</ns2:iceSeriesDose>
     <ns2:seasonCode>DefaultInfluenzaSeason</ns2:seasonCode>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseDefaultSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseDefaultSeries.xml
@@ -124,7 +124,7 @@
         </ns2:doseVaccine>
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, MDCK, trivalent, preservative"/>
         </ns2:doseVaccine>
     </ns2:iceSeriesDose>
     <ns2:iceSeriesDose>
@@ -235,7 +235,7 @@
         </ns2:doseVaccine>
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, MDCK, trivalent, preservative"/>
         </ns2:doseVaccine>
 	</ns2:iceSeriesDose>
     <ns2:seasonCode>DefaultInfluenzaSeason</ns2:seasonCode>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseSeries.xml
@@ -124,7 +124,7 @@
         </ns2:doseVaccine>
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, MDCK, trivalent, preservative"/>
         </ns2:doseVaccine>
     </ns2:iceSeriesDose>
     <ns2:iceSeriesDose>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/Influenza2DoseSeries.xml
@@ -122,6 +122,10 @@
             <ns2:preferred>false</ns2:preferred>
             <ns2:vaccine code="231" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="influenza, Southern Hemisphere, high-dose, quadrivalent"/>
         </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
+        </ns2:doseVaccine>
     </ns2:iceSeriesDose>
     <ns2:iceSeriesDose>
         <ns2:doseNumber>2</ns2:doseNumber>
@@ -228,6 +232,10 @@
         <ns2:doseVaccine>
             <ns2:preferred>false</ns2:preferred>
             <ns2:vaccine code="231" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="influenza, Southern Hemisphere, high-dose, quadrivalent"/>
+        </ns2:doseVaccine>
+        <ns2:doseVaccine>
+            <ns2:preferred>true</ns2:preferred>
+            <ns2:vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, injectable, MDCK, preservative"/>
         </ns2:doseVaccine>
     </ns2:iceSeriesDose>
     <ns2:seasonCode>20122013InfluenzaSeason</ns2:seasonCode>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Vaccines/320.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Vaccines/320.xml
@@ -3,6 +3,7 @@
     <vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, MDCK, trivalent, preservative"/>
     <cdsVersion>gov.nyc.cir^ICE^1.0.0</cdsVersion>
     <ns2:liveVirusVaccine>false</ns2:liveVirusVaccine>
+    <ns2:unspecifiedFormulation>false</ns2:unspecifiedFormulation>
     <ns2:vaccineActive>true</ns2:vaccineActive>
     <ns2:manufacturerCode/>
     <ns2:validMinimumAgeForUse>6m-4d</ns2:validMinimumAgeForUse>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Vaccines/320.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Vaccines/320.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:iceVaccineSpecificationFile xmlns:ns2="org.cdsframework.util.support.data.ice.vaccine">
+    <vaccine code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, MDCK, trivalent, preservative"/>
+    <cdsVersion>gov.nyc.cir^ICE^1.0.0</cdsVersion>
+    <ns2:liveVirusVaccine>false</ns2:liveVirusVaccine>
+    <ns2:vaccineActive>true</ns2:vaccineActive>
+    <ns2:manufacturerCode/>
+    <ns2:validMinimumAgeForUse>6m-4d</ns2:validMinimumAgeForUse>
+    <vaccineComponent code="320" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Influenza, MDCK, trivalent, preservative"/>
+    <diseaseImmunity code="487" codeSystem="2.16.840.1.113883.6.103" codeSystemName="ICD9CM Diagnosis" displayName="Influenza"/>
+    <primaryOpenCdsConcept code="ICE320"/>
+</ns2:iceVaccineSpecificationFile>


### PR DESCRIPTION
Add new CVX code for a fall 2024 flu vaccine into flu forecasting. For the fall 2024 flu season, vaccines are reverting back to trivalent formulations, which were previously used years ago before the transition to quadrivalent.