### PR TITLE
PEDS-5064 Reduce the grace period of first dose and adjust min date forecast for MenB

### DIFF
--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenB4C2DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenB4C2DoseSeries.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns2:iceSeriesSpecificationFile xmlns:ns2="org.cdsframework.util.support.data.ice.series">
-    <ns2:seriesId>e4ce9fdf5eefebfb26e35a5a91e8861d</ns2:seriesId>
-    <ns2:name>MenB 4C 2-dose Series</ns2:name>
-    <ns2:code>MenB4C2DoseSeries</ns2:code>
-    <ns2:cdsVersion>gov.nyc.cir^ICE^1.0.0</ns2:cdsVersion>
-    <ns2:doseInterval>
-        <ns2:fromDoseNumber>1</ns2:fromDoseNumber>
-        <ns2:toDoseNumber>2</ns2:toDoseNumber>
-        <ns2:absoluteMinimumInterval>1m-4d</ns2:absoluteMinimumInterval>
-        <ns2:minimumInterval>1m</ns2:minimumInterval>
-        <ns2:earliestRecommendedInterval>1m</ns2:earliestRecommendedInterval>
-    </ns2:doseInterval>
-    <ns2:numberOfDosesInSeries>2</ns2:numberOfDosesInSeries>
-    <ns2:vaccineGroup code="835" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="Meningococcal B"/>
-    <ns2:iceSeriesDose>
-        <ns2:doseNumber>1</ns2:doseNumber>
-        <ns2:absoluteMinimumAge>10y-4d</ns2:absoluteMinimumAge>
-        <ns2:minimumAge>10y</ns2:minimumAge>
-        <ns2:earliestRecommendedAge>10y</ns2:earliestRecommendedAge>
-        <ns2:doseVaccine>
-            <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="163" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B 4C, OMV"/>
-        </ns2:doseVaccine>
-    </ns2:iceSeriesDose>
-    <ns2:iceSeriesDose>
-        <ns2:doseNumber>2</ns2:doseNumber>
-        <ns2:earliestRecommendedAge>10y1m</ns2:earliestRecommendedAge>
-        <ns2:doseVaccine>
-            <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="163" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B 4C, OMV"/>
-        </ns2:doseVaccine>
-    </ns2:iceSeriesDose>
+  <ns2:seriesId>e4ce9fdf5eefebfb26e35a5a91e8861d</ns2:seriesId>
+  <ns2:name>MenB 4C 2-dose Series</ns2:name>
+  <ns2:code>MenB4C2DoseSeries</ns2:code>
+  <ns2:cdsVersion>gov.nyc.cir^ICE^1.0.0</ns2:cdsVersion>
+  <ns2:doseInterval>
+    <ns2:fromDoseNumber>1</ns2:fromDoseNumber>
+    <ns2:toDoseNumber>2</ns2:toDoseNumber>
+    <ns2:absoluteMinimumInterval>1m-4d</ns2:absoluteMinimumInterval>
+    <ns2:minimumInterval>1m</ns2:minimumInterval>
+    <ns2:earliestRecommendedInterval>1m</ns2:earliestRecommendedInterval>
+  </ns2:doseInterval>
+  <ns2:numberOfDosesInSeries>2</ns2:numberOfDosesInSeries>
+  <ns2:vaccineGroup code="835" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="Meningococcal B"/>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>1</ns2:doseNumber>
+    <ns2:absoluteMinimumAge>10y-4d</ns2:absoluteMinimumAge>
+    <ns2:minimumAge>10y</ns2:minimumAge>
+    <ns2:earliestRecommendedAge>10y</ns2:earliestRecommendedAge>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="163" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B 4C, OMV"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>2</ns2:doseNumber>
+    <ns2:earliestRecommendedAge>10y1m</ns2:earliestRecommendedAge>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="163" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B 4C, OMV"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
 </ns2:iceSeriesSpecificationFile>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenBFHbp2DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenBFHbp2DoseSeries.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns2:iceSeriesSpecificationFile xmlns:ns2="org.cdsframework.util.support.data.ice.series">
-    <ns2:seriesId>e4ce9fdf5eefebfb26e35a5a91e8861d</ns2:seriesId>
-    <ns2:name>MenB FHbp 2-dose series</ns2:name>
-    <ns2:code>MenBFHbp2DoseSeries</ns2:code>
-    <ns2:cdsVersion>gov.nyc.cir^ICE^1.0.0</ns2:cdsVersion>
-    <ns2:doseInterval>
-        <ns2:fromDoseNumber>1</ns2:fromDoseNumber>
-        <ns2:toDoseNumber>2</ns2:toDoseNumber>
-        <ns2:absoluteMinimumInterval>6m-4d</ns2:absoluteMinimumInterval>
-        <ns2:minimumInterval>6m</ns2:minimumInterval>
-        <ns2:earliestRecommendedInterval>6m</ns2:earliestRecommendedInterval>
-    </ns2:doseInterval>
-    <ns2:numberOfDosesInSeries>2</ns2:numberOfDosesInSeries>
-    <ns2:vaccineGroup code="835" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="Meningococcal B"/>
-    <ns2:iceSeriesDose>
-        <ns2:doseNumber>1</ns2:doseNumber>
-        <ns2:absoluteMinimumAge>16y-4d</ns2:absoluteMinimumAge>
-        <ns2:minimumAge>16y</ns2:minimumAge>
-        <ns2:earliestRecommendedAge>16y</ns2:earliestRecommendedAge>
-        <ns2:doseVaccine>
-            <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
-        </ns2:doseVaccine>
-    </ns2:iceSeriesDose>
-    <ns2:iceSeriesDose>
-        <ns2:doseNumber>2</ns2:doseNumber>
-        <ns2:doseVaccine>
-            <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
-        </ns2:doseVaccine>
-    </ns2:iceSeriesDose>
+  <ns2:seriesId>e4ce9fdf5eefebfb26e35a5a91e8861d</ns2:seriesId>
+  <ns2:name>MenB FHbp 2-dose series</ns2:name>
+  <ns2:code>MenBFHbp2DoseSeries</ns2:code>
+  <ns2:cdsVersion>gov.nyc.cir^ICE^1.0.0</ns2:cdsVersion>
+  <ns2:doseInterval>
+    <ns2:fromDoseNumber>1</ns2:fromDoseNumber>
+    <ns2:toDoseNumber>2</ns2:toDoseNumber>
+    <ns2:absoluteMinimumInterval>6m-4d</ns2:absoluteMinimumInterval>
+    <ns2:minimumInterval>6m</ns2:minimumInterval>
+    <ns2:earliestRecommendedInterval>6m</ns2:earliestRecommendedInterval>
+  </ns2:doseInterval>
+  <ns2:numberOfDosesInSeries>2</ns2:numberOfDosesInSeries>
+  <ns2:vaccineGroup code="835" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="Meningococcal B"/>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>1</ns2:doseNumber>
+    <ns2:absoluteMinimumAge>10y-4d</ns2:absoluteMinimumAge>
+    <ns2:minimumAge>10y</ns2:minimumAge>
+    <ns2:earliestRecommendedAge>10y</ns2:earliestRecommendedAge>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>2</ns2:doseNumber>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
 </ns2:iceSeriesSpecificationFile>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenBFHbp3DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenBFHbp3DoseSeries.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns2:iceSeriesSpecificationFile xmlns:ns2="org.cdsframework.util.support.data.ice.series">
-    <ns2:seriesId>e4ce9fdf5eefebfb26e35a5a91e8861d</ns2:seriesId>
-    <ns2:name>MenB FHbp 3-dose series</ns2:name>
-    <ns2:code>MenBFHbp3DoseSeries</ns2:code>
-    <ns2:cdsVersion>gov.nyc.cir^ICE^1.0.0</ns2:cdsVersion>
-    <ns2:doseInterval>
-        <ns2:fromDoseNumber>1</ns2:fromDoseNumber>
-        <ns2:toDoseNumber>2</ns2:toDoseNumber>
-        <ns2:absoluteMinimumInterval>4w-4d</ns2:absoluteMinimumInterval>
-        <ns2:minimumInterval>4w</ns2:minimumInterval>
-        <ns2:earliestRecommendedInterval>4w</ns2:earliestRecommendedInterval>
-    </ns2:doseInterval>
-	<ns2:doseInterval>
-        <ns2:fromDoseNumber>2</ns2:fromDoseNumber>
-        <ns2:toDoseNumber>3</ns2:toDoseNumber>
-        <ns2:absoluteMinimumInterval>4m-4d</ns2:absoluteMinimumInterval>
-        <ns2:minimumInterval>4m</ns2:minimumInterval>
-        <ns2:earliestRecommendedInterval>4m</ns2:earliestRecommendedInterval>
-    </ns2:doseInterval>    
-    <ns2:numberOfDosesInSeries>3</ns2:numberOfDosesInSeries>
-    <ns2:vaccineGroup code="835" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="Meningococcal B"/>
-    <ns2:iceSeriesDose>
-        <ns2:doseNumber>1</ns2:doseNumber>
-        <ns2:absoluteMinimumAge>10y-4d</ns2:absoluteMinimumAge>
-        <ns2:minimumAge>10y</ns2:minimumAge>
-        <ns2:earliestRecommendedAge>10y</ns2:earliestRecommendedAge>
-        <ns2:doseVaccine>
-            <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
-        </ns2:doseVaccine>
-    </ns2:iceSeriesDose>
-    <ns2:iceSeriesDose>
-        <ns2:doseNumber>2</ns2:doseNumber>
-        <ns2:doseVaccine>
-            <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
-        </ns2:doseVaccine>
-    </ns2:iceSeriesDose>
-    <ns2:iceSeriesDose>
-        <ns2:doseNumber>3</ns2:doseNumber>
-        <ns2:doseVaccine>
-            <ns2:preferred>true</ns2:preferred>
-            <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
-        </ns2:doseVaccine>
-    </ns2:iceSeriesDose>
+  <ns2:seriesId>e4ce9fdf5eefebfb26e35a5a91e8861d</ns2:seriesId>
+  <ns2:name>MenB FHbp 3-dose series</ns2:name>
+  <ns2:code>MenBFHbp3DoseSeries</ns2:code>
+  <ns2:cdsVersion>gov.nyc.cir^ICE^1.0.0</ns2:cdsVersion>
+  <ns2:doseInterval>
+    <ns2:fromDoseNumber>1</ns2:fromDoseNumber>
+    <ns2:toDoseNumber>2</ns2:toDoseNumber>
+    <ns2:absoluteMinimumInterval>4w-4d</ns2:absoluteMinimumInterval>
+    <ns2:minimumInterval>4w</ns2:minimumInterval>
+    <ns2:earliestRecommendedInterval>4w</ns2:earliestRecommendedInterval>
+  </ns2:doseInterval>
+  <ns2:doseInterval>
+    <ns2:fromDoseNumber>2</ns2:fromDoseNumber>
+    <ns2:toDoseNumber>3</ns2:toDoseNumber>
+    <ns2:absoluteMinimumInterval>4m-4d</ns2:absoluteMinimumInterval>
+    <ns2:minimumInterval>4m</ns2:minimumInterval>
+    <ns2:earliestRecommendedInterval>4m</ns2:earliestRecommendedInterval>
+  </ns2:doseInterval>
+  <ns2:numberOfDosesInSeries>3</ns2:numberOfDosesInSeries>
+  <ns2:vaccineGroup code="835" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="Meningococcal B"/>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>1</ns2:doseNumber>
+    <ns2:absoluteMinimumAge>10y-4d</ns2:absoluteMinimumAge>
+    <ns2:minimumAge>10y</ns2:minimumAge>
+    <ns2:earliestRecommendedAge>10y</ns2:earliestRecommendedAge>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>2</ns2:doseNumber>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>3</ns2:doseNumber>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="162" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B FHbp, recombinant"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
 </ns2:iceSeriesSpecificationFile>


### PR DESCRIPTION
- The grace period for a shot given under exactly that condition should have a grace period down to age 10, which would be in concert with the youngest age recommended for a patient who was noted to be high risk.

- The dose will be considered valid in VL+ and not flagged

- The next forecast dose will need to respect THE MINIMUM interval recommended between dose 1 and dose 2, taking into account which Men B vaccine (Bexsero, Trumenba, or Penbraya) was administered