### PR TITLE
Feat/peds 5862 Recommended immunization schedule changes for Bexsero (MenB-4C)

### DIFF
--- a/src/main/kotlin/com/connexin/ice/wrapper/Constants.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/Constants.kt
@@ -4,6 +4,8 @@ class Constants {
     object FlagConstants {
         const val FLAG_RSV_INDICATED = "rsvIndicated"
         const val FLAG_SYNAGIS_INDICATED = "synagisIndicated"
+        const val FLAG_MENB_SINGLE = "menBIndicatedSingle"
+        const val FLAG_MENB_HIGH_RISK = "menBIndicatedHighRisk"
     }
 
     object DiseaseCodes {

--- a/src/main/kotlin/com/connexin/ice/wrapper/service/op/OPEngine.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/service/op/OPEngine.kt
@@ -72,6 +72,8 @@ class OPEngine(private val kieContainer: KieContainer,
             session.addEventListener(agendaEventListener)
         }
         val isRsvIndicated = vaccineReport.flags?.get(Constants.FlagConstants.FLAG_RSV_INDICATED) ?: vaccineReport.flags?.get(Constants.FlagConstants.FLAG_SYNAGIS_INDICATED)
+        val isMenBSharedDecision = vaccineReport.flags?.get(Constants.FlagConstants.FLAG_MENB_SINGLE) ?: false
+        val isMenBHighRisk = vaccineReport.flags?.get(Constants.FlagConstants.FLAG_MENB_HIGH_RISK) ?: false
         val mommyVaxGiven = vaccineReport.indicators.any {
             it.interpretation == Interpretation.PREGNANCY_VACCINATED && it.code == Constants.DiseaseCodes.ICE_RSV_DISEASE_CODE
                     && it.date.isBefore(vaccineReport.dateOfBirth.minusDays(13))
@@ -96,6 +98,8 @@ class OPEngine(private val kieContainer: KieContainer,
         cmds.add(CommandFactory.newSetGlobal("februaryStartMonthDay", org.joda.time.MonthDay(2, 1)))
         cmds.add(CommandFactory.newSetGlobal("isRSVHighRisk", isRsvIndicated == true))
         cmds.add(CommandFactory.newSetGlobal("wasMommyVaxGiven", mommyVaxGiven))
+        cmds.add(CommandFactory.newSetGlobal("isMenBSharedDecision", isMenBSharedDecision))
+        cmds.add(CommandFactory.newSetGlobal("isMenBHighRisk", isMenBHighRisk))
 
 
 

--- a/src/main/resources/rules/v1.39.2.3/knowledgeCommon/org.cdsframework.ice/ice-supporting-data/OtherLists/supportedRecommendationReasons.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeCommon/org.cdsframework.ice/ice-supporting-data/OtherLists/supportedRecommendationReasons.xml
@@ -26,7 +26,7 @@
    </cdsListItem>
    <cdsListItem>
         <cdsListItemKey>HIGH_RISK</cdsListItemKey>
-        <cdsListItemValue>Recommended for high-risk groups MM.</cdsListItemValue>
+        <cdsListItemValue>Recommended for high-risk groups.</cdsListItemValue>
    </cdsListItem>
    <cdsListItem>
         <cdsListItemKey>NOT_SPECIFIED</cdsListItemKey>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeCommon/org.cdsframework.ice/ice-supporting-data/OtherLists/supportedRecommendationReasons.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeCommon/org.cdsframework.ice/ice-supporting-data/OtherLists/supportedRecommendationReasons.xml
@@ -26,7 +26,7 @@
    </cdsListItem>
    <cdsListItem>
         <cdsListItemKey>HIGH_RISK</cdsListItemKey>
-        <cdsListItemValue>Recommended for high-risk groups.</cdsListItemValue>
+        <cdsListItemValue>Recommended for high-risk groups MM.</cdsListItemValue>
    </cdsListItem>
    <cdsListItem>
         <cdsListItemKey>NOT_SPECIFIED</cdsListItemKey>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Recommendation^MeningB.dslr
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Recommendation^MeningB.dslr
@@ -51,6 +51,8 @@ expander ../../knowledgeCommon/org.cdsframework.ice/org.cdsframework^ICE^1.0.0.d
 
 global java.util.Date evalTime
 global org.cdsframework.ice.service.Schedule schedule
+global java.lang.Boolean isMenBSharedDecision
+global java.lang.Boolean isMenBHighRisk
 
 
 /*************************************************************************************************************************************************************************************
@@ -68,7 +70,7 @@ rule "Mening B: Do not recommend a specific vaccine if no (valid) doses have bee
 			- a forecast for the Series has been made and a Specific Vaccine is Recommended
 			- the effective dose number in the Series is == 1
 	then
-		Unset the Recommended Vaccine for the forecast in the Series $targetSeries
+		// Unset the Recommended Vaccine for the forecast in the Series $targetSeries
 		Record that this Series Rule was Processed for the TargetSeries $targetSeries
        	Log that this Series Rule fired for the Series $targetSeries
 end
@@ -84,9 +86,9 @@ rule "Mening B: Recommend CVX 163 for the 2nd target dose in the MenB 4C 2-dose 
 			- the name of the series is "MenB4C2DoseSeries"
 			
 	then
-		Create a Recommendation as $oRecommendation for the Series $targetSeries
-		Set the Recommendation Vaccine for $oRecommendation to "ICE163"
-		Include the Recommendation $oRecommendation for Consideration in the final forecast of the Series
+		//Create a Recommendation as $oRecommendation for the Series $targetSeries
+		//Set the Recommendation Vaccine for $oRecommendation to "ICE163"
+		//Include the Recommendation $oRecommendation for Consideration in the final forecast of the Series
 		Record that this Series Rule was Processed for the TargetSeries $targetSeries
        	Log that this Series Rule fired for the Series $targetSeries
 end
@@ -184,48 +186,104 @@ rule "Mening B: If the patient < 10yrs and no doses on record, recommendation is
 		Log that this Series Rule fired for the Series $targetSeries
 end
 
-
-rule "Mening B: If the patient >= 10yrs and < 16yrs and no doses on record, recommendation is CONDITIONAL/HIGH_RISK"
+rule "Mening B: If the patient is in high risk group, start recommending since 10 years through 23 years"
 	dialect "mvel"
-	agenda-group "RecommendationForecast^customRecommendationRule"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	no-loop true
 	when
-		There is a Series $targetSeries that needs forecasting
+		There is a Series $targetSeries
 			- the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.835"
 			- the number of doses administered is == 0
 		The Patient information $patientInfo must be known to complete writing this rule
 			- make note of the Patient's birthdate as $birthdate
 		Confirm elapsed time between $birthdate and evalTime >= "10y"
-		Confirm elapsed time between $birthdate and evalTime < "16y"
+		Confirm elapsed time between $birthdate and evalTime < "23y"
+		Confirm the variable isMenBHighRisk is == true
 	then
-		Create a Recommendation as $recommendation with Status RecommendationStatus.CONDITIONALLY_RECOMMENDED for the Series $targetSeries
-		Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.HIGH_RISK"
+	  Clear forecasted recommendations from consideration in series $targetSeries
+		Create a Recommendation as $recommendation with Status RecommendationStatus.RECOMMENDED for the Series $targetSeries
+		Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.MENB_HIGH_RISK"
 		Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
 		Record that this Series Rule was Processed for the TargetSeries $targetSeries
 		Log that this Series Rule fired for the Series $targetSeries
 end
 
-
-rule "Mening B: If the patient >= 16yrs and < 24yrs and no doses on record, recommendation is CONDITIONAL/CLINICAL_PATIENT_DISCRETION"
-	dialect "mvel"
-	agenda-group "RecommendationForecast^customRecommendationRule"
+rule "Mening B(Abstract): The series forecasting right now is for high risk"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	salience -10
+	no-loop true
 	when
-		There is a Series $targetSeries that needs forecasting
+		There is a Series $targetSeries
+			- the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.835"
+			- the name of the series is "MenB4C2DoseSeries"
+			- a forecast for the Series has been made and a shot is Recommended
+			- the Series is not Complete
+			//- the effective dose number in the Series is == 1
+		The Patient information $patientInfo must be known to complete writing this rule
+			- make note of the Patient's birthdate as $birthdate
+			- make note of the date as $dtDateAtAge10y when the patient is "10y" of age
+			- make note of the date as $dtDateAtAge16y when the patient is "16y" of age
+		There is an Administered Shot $dose1
+			- the Shot belongs to the Series $targetSeries
+			- the Dose Number in the Series is == 1
+			- that has already been Evaluated and whose Shot Validity is VALID
+			- the administration date of the shot is > $dtDateAtAge10y
+			- the administration date of the shot is < $dtDateAtAge16y
+			- Make note of the Date this Shot was Administered as $dtAdministrationDate1
+		//Confirm the variable isMenBHighRisk is == true
+	then
+		Record that this Series Rule was Processed for the TargetSeries $targetSeries
+    Log that this Series Rule fired for the Series $targetSeries
+end
+
+rule "Mening B: When at high risk, end forecasting upon second valid vaccine 6 months apart" extends
+    "Mening B(Abstract): The series forecasting right now is for high risk"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	salience -10
+	no-loop true
+	when
+		There is a Series $associatedTargetSeries identified by $targetSeries
+			- the effective dose number in the Series is == 3
+		There is an Administered Shot $dose2
+			- the Shot belongs to the Series $targetSeries
+			- the Dose Number in the Series is == 2
+			- that has already been Evaluated and whose Shot Validity is VALID
+			- Make note of the Date this Shot was Administered as $dtAdministrationDate2
+		Confirm elapsed time between $dtAdministrationDate1 and $dtAdministrationDate2 >= "6m"
+	then
+	  Clear forecasted recommendations from consideration in series $targetSeries
+		Create a Recommendation as $recommendation with Status RecommendationStatus.NOT_RECOMMENDED for the Series $targetSeries
+    Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.COMPLETE"
+    Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
+    Mark Forecasting of the Series $targetSeries Complete
+		Record that this Series Rule was Processed for the TargetSeries $targetSeries
+    Log that this Series Rule fired for the Series $targetSeries
+end
+
+rule "Mening B: If the patient is in shared decision making group, start recommending since 16 years through 23 years"
+	dialect "mvel"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	no-loop true
+	when
+		There is a Series $targetSeries
 			- the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.835"
 			- the number of doses administered is == 0
 		The Patient information $patientInfo must be known to complete writing this rule
 			- make note of the Patient's birthdate as $birthdate
 		Confirm elapsed time between $birthdate and evalTime >= "16y"
-		Confirm elapsed time between $birthdate and evalTime < "24y"
+		Confirm elapsed time between $birthdate and evalTime < "23y"
+		Confirm the variable isMenBSharedDecision is == true
 	then
-		Create a Recommendation as $recommendation with Status RecommendationStatus.CONDITIONALLY_RECOMMENDED for the Series $targetSeries
-		Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.CLINICAL_PATIENT_DISCRETION"
+	  Clear forecasted recommendations from consideration in series $targetSeries
+		Create a Recommendation as $recommendation with Status RecommendationStatus.RECOMMENDED for the Series $targetSeries
+		Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.MENB_SHARED_DECISION"
 		Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
 		Record that this Series Rule was Processed for the TargetSeries $targetSeries
 		Log that this Series Rule fired for the Series $targetSeries
 end
 
 
-rule "Mening B: If the patient >= 24yrs and no doses on record, recommendation is CONDITIONAL/HIGH_RISK"
+rule "Mening B: If the patient >= 24yrs and no doses on record, recommendation is N/A"
 	dialect "mvel"
 	agenda-group "RecommendationForecast^customRecommendationRule"
 	when
@@ -236,11 +294,113 @@ rule "Mening B: If the patient >= 24yrs and no doses on record, recommendation i
 			- make note of the Patient's birthdate as $birthdate
 		Confirm elapsed time between $birthdate and evalTime >= "24y"
 	then
-		Create a Recommendation as $recommendation with Status RecommendationStatus.CONDITIONALLY_RECOMMENDED for the Series $targetSeries
-		Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.HIGH_RISK"
+		Clear forecasted recommendations from consideration in series $targetSeries
+		Create a Recommendation as $recommendation with Status RecommendationStatus.NOT_RECOMMENDED for the Series $targetSeries
+		Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.MENB_SHARED_DECISION_NOT_APPLICABLE"
 		Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
 		Record that this Series Rule was Processed for the TargetSeries $targetSeries
 		Log that this Series Rule fired for the Series $targetSeries
+end
+
+rule "Mening B: Ensure that third dose is at least 6 months apart from first dose"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	salience -5
+	no-loop true
+	when
+		There is a Series $targetSeries
+			- the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.835"
+			- the name of the series is "MenB4C2DoseSeries"
+			- a forecast for the Series has been made and a shot is Recommended
+      - Make note of the earliest date as $earliestDate
+			- the Series is not Complete
+			- the effective dose number in the Series is == 3
+		There is an Administered Shot $dose1
+			- the Shot belongs to the Series $targetSeries
+			- the Dose Number in the Series is == 1
+			- that has already been Evaluated and whose Shot Validity is VALID
+			- Make note of the Date this Shot was Administered as $dtAdministrationDate
+	then
+		Add "6m" to $dtAdministrationDate and make note of the newly calculated date as $dtCalculated
+		Create a Recommendation as $recommendation with Status RecommendationStatus.RECOMMENDED for the Series $targetSeries
+		Calculate the latter of $dtCalculated and $earliestDate and save calculated date as $earliestMenBDate
+		Set the Final recommendation earliest forecast date on series $targetSeries to $earliestMenBDate
+		Set the Final recommendation recommended forecast date on series $targetSeries to $earliestMenBDate
+		Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
+		Record that this Series Rule was Processed for the TargetSeries $targetSeries
+    Log that this Series Rule fired for the Series $targetSeries
+end
+
+
+rule "Mening B(Abstract): The series forecasting right now is for shared decision making"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	salience -10
+	no-loop true
+	when
+		There is a Series $targetSeries
+			- the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.835"
+			- the name of the series is "MenB4C2DoseSeries"
+			- a forecast for the Series has been made and a shot is Recommended
+			- the Series is not Complete
+			- the effective dose number in the Series is > 1
+		The Patient information $patientInfo must be known to complete writing this rule
+			- make note of the Patient's birthdate as $birthdate
+			- make note of the date as $dtDateAtAge16y when the patient is "16y" of age
+			- make note of the date as $dtDateAtAge23y when the patient is "23y" of age
+		There is an Administered Shot $dose1
+			- the Shot belongs to the Series $targetSeries
+			- the Dose Number in the Series is == 1
+			- that has already been Evaluated and whose Shot Validity is VALID
+			- the administration date of the shot is >= $dtDateAtAge16y
+			- the administration date of the shot is < $dtDateAtAge23y
+			- Make note of the Date this Shot was Administered as $dtAdministrationDate1
+		Confirm the variable isMenBHighRisk is == false
+	then
+		Record that this Series Rule was Processed for the TargetSeries $targetSeries
+    Log that this Series Rule fired for the Series $targetSeries
+end
+
+rule "Mening B: When at shared decision making, end forecasting upon second valid vaccine 6 months apart" extends
+    "Mening B(Abstract): The series forecasting right now is for shared decision making"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	salience -10
+	no-loop true
+	when
+		There is a Series $associatedTargetSeries identified by $targetSeries
+			- the effective dose number in the Series is == 3
+		There is an Administered Shot $dose2
+			- the Shot belongs to the Series $targetSeries
+			- the Dose Number in the Series is == 2
+			- that has already been Evaluated and whose Shot Validity is VALID
+			- Make note of the Date this Shot was Administered as $dtAdministrationDate2
+		Confirm elapsed time between $dtAdministrationDate1 and $dtAdministrationDate2 >= "6m"
+	then
+	  Clear forecasted recommendations from consideration in series $targetSeries
+		Create a Recommendation as $recommendation with Status RecommendationStatus.NOT_RECOMMENDED for the Series $targetSeries
+    Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.COMPLETE"
+    Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
+    Mark Forecasting of the Series $targetSeries Complete
+		Record that this Series Rule was Processed for the TargetSeries $targetSeries
+    Log that this Series Rule fired for the Series $targetSeries
+end
+
+
+rule "Mening B: When at shared decision making, second dose recommendation is 6 months apart" extends
+    "Mening B(Abstract): The series forecasting right now is for shared decision making"
+	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
+	salience -10
+	no-loop true
+	when
+		There is a Series $associatedTargetSeries identified by $targetSeries
+			- the effective dose number in the Series is == 2
+	then
+	  Clear forecasted recommendations from consideration in series $targetSeries
+	  Create a Recommendation as $recommendation with Status RecommendationStatus.RECOMMENDED for the Series $targetSeries
+		Add "6m" to $dtAdministrationDate1 and make note of the newly calculated date as $dtCalculated
+		Set the Recommendation Recommended Forecast Date for $recommendation to $dtCalculated
+		Set the Recommendation Earliest  Forecast Date for $recommendation to $dtCalculated
+		Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
+		Record that this Series Rule was Processed for the TargetSeries $targetSeries
+    Log that this Series Rule fired for the Series $targetSeries
 end
 
 

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/OtherLists/supportedRecommendationReasons.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/OtherLists/supportedRecommendationReasons.xml
@@ -79,5 +79,17 @@
         <cdsListItemKey>ADMINISTER_2023_24_FORMULATION_COVID19</cdsListItemKey>
         <cdsListItemValue>2023-2024 Formulation of Covid19 vaccine should be administered.</cdsListItemValue>
     </cdsListItem>
+    <cdsListItem>
+      <cdsListItemKey>MENB_HIGH_RISK</cdsListItemKey>
+      <cdsListItemValue>High risk patients should receive the vaccine series starting at age 10+</cdsListItemValue>
+    </cdsListItem>
+    <cdsListItem>
+      <cdsListItemKey>MENB_SHARED_DECISION</cdsListItemKey>
+      <cdsListItemValue>Series recommended to start at age 16+</cdsListItemValue>
+    </cdsListItem>
+  <cdsListItem>
+    <cdsListItemKey>MENB_SHARED_DECISION_NOT_APPLICABLE</cdsListItemKey>
+    <cdsListItemValue>Not Applicable</cdsListItemValue>
+  </cdsListItem>
    <cdsVersion>gov.nyc.cir^ICE^1.0.0</cdsVersion>
 </ns2:cdsListSpecificationFile>

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenB4C2DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/MenB4C2DoseSeries.xml
@@ -9,9 +9,17 @@
     <ns2:toDoseNumber>2</ns2:toDoseNumber>
     <ns2:absoluteMinimumInterval>1m-4d</ns2:absoluteMinimumInterval>
     <ns2:minimumInterval>1m</ns2:minimumInterval>
-    <ns2:earliestRecommendedInterval>1m</ns2:earliestRecommendedInterval>
+    <ns2:earliestRecommendedInterval>2m</ns2:earliestRecommendedInterval>
+    <ns2:latestRecommendedInterval>6m</ns2:latestRecommendedInterval>
   </ns2:doseInterval>
-  <ns2:numberOfDosesInSeries>2</ns2:numberOfDosesInSeries>
+  <ns2:doseInterval>
+    <ns2:fromDoseNumber>2</ns2:fromDoseNumber>
+    <ns2:toDoseNumber>3</ns2:toDoseNumber>
+    <ns2:absoluteMinimumInterval>4m-4d</ns2:absoluteMinimumInterval>
+    <ns2:minimumInterval>4m</ns2:minimumInterval>
+    <ns2:earliestRecommendedInterval>4m</ns2:earliestRecommendedInterval>
+  </ns2:doseInterval>
+  <ns2:numberOfDosesInSeries>3</ns2:numberOfDosesInSeries>
   <ns2:vaccineGroup code="835" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="Meningococcal B"/>
   <ns2:iceSeriesDose>
     <ns2:doseNumber>1</ns2:doseNumber>
@@ -26,6 +34,14 @@
   <ns2:iceSeriesDose>
     <ns2:doseNumber>2</ns2:doseNumber>
     <ns2:earliestRecommendedAge>10y1m</ns2:earliestRecommendedAge>
+    <ns2:doseVaccine>
+      <ns2:preferred>true</ns2:preferred>
+      <ns2:vaccine code="163" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B 4C, OMV"/>
+    </ns2:doseVaccine>
+  </ns2:iceSeriesDose>
+  <ns2:iceSeriesDose>
+    <ns2:doseNumber>3</ns2:doseNumber>
+    <ns2:earliestRecommendedAge>10y6m</ns2:earliestRecommendedAge>
     <ns2:doseVaccine>
       <ns2:preferred>true</ns2:preferred>
       <ns2:vaccine code="163" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Meningococcal B 4C, OMV"/>


### PR DESCRIPTION
Adding new conditions and rules in order to match the forecasting schedule for Bexero, and introducing menB indicators to the rules.