### PR TITLE
PEDS-5862 Add case when the bexero 3-series is completed in a second dose

### DIFF
--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Recommendation^MeningB.dslr
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Recommendation^MeningB.dslr
@@ -227,7 +227,7 @@ rule "Mening B(Abstract): The series forecasting right now is for high risk"
 			- the Shot belongs to the Series $targetSeries
 			- the Dose Number in the Series is == 1
 			- that has already been Evaluated and whose Shot Validity is VALID
-			- the administration date of the shot is > $dtDateAtAge10y
+			- the administration date of the shot is >= $dtDateAtAge10y
 			- the administration date of the shot is < $dtDateAtAge16y
 			- Make note of the Date this Shot was Administered as $dtAdministrationDate1
 		//Confirm the variable isMenBHighRisk is == true


### PR DESCRIPTION
This case happens when a Bexero 3-series started already but the second dose is applied after 6mo from the first dose, then the shot is VALID and completes the series.