### PR TITLE
PEDS-6328 Remove RSV changes intended for a future release

### DIFF
--- a/src/main/kotlin/com/connexin/ice/wrapper/service/op/OPEngine.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/service/op/OPEngine.kt
@@ -120,10 +120,6 @@ class OPEngine(
         cmds.add(CommandFactory.newSetGlobal("firstRSVSeasonEnd", rsvSeasonDates.firstSeasonEnd.toDate()))
         cmds.add(CommandFactory.newSetGlobal("secondRSVSeasonStart", rsvSeasonDates.secondSeasonStart.toDate()))
         cmds.add(CommandFactory.newSetGlobal("secondRSVSeasonEnd", rsvSeasonDates.secondSeasonEnd.toDate()))
-        cmds.add(CommandFactory.newSetGlobal("extendedFirstRSVSeasonStart", rsvSeasonDates.extendedFirstSeasonStart.toDate()))
-        cmds.add(CommandFactory.newSetGlobal("extendedFirstRSVSeasonEnd", rsvSeasonDates.extendedFirstSeasonEnd.toDate()))
-        cmds.add(CommandFactory.newSetGlobal("extendedSecondRSVSeasonStart", rsvSeasonDates.extendedSecondSeasonStart.toDate()))
-        cmds.add(CommandFactory.newSetGlobal("extendedSecondRSVSeasonEnd", rsvSeasonDates.extendedSecondSeasonEnd.toDate()))
 
         val vmr = convertToIceModel(vaccineReport)
         val jaxb = unmarshal(vmr)
@@ -367,20 +363,14 @@ class OPEngine(
         val firstSeasonStart: LocalDate,
         val firstSeasonEnd: LocalDate,
         val secondSeasonStart: LocalDate,
-        val secondSeasonEnd: LocalDate,
-        val extendedFirstSeasonStart: LocalDate,
-        val extendedFirstSeasonEnd: LocalDate,
-        val extendedSecondSeasonStart: LocalDate,
-        val extendedSecondSeasonEnd: LocalDate,
+        val secondSeasonEnd: LocalDate
     )
 
     private fun calculateRsvSeasonDates(birthdate: LocalDate): RsvSeasonDates {
         // Define constant season boundaries
         val rsvSeasonStartMonth = Month.OCTOBER
-        val extendedRsvSeasonStartMonth = Month.SEPTEMBER
         val rsvSeasonStartDay = 1
         val rsvSeasonEndMonth = Month.MARCH
-        val extendedRsvSeasonEndMonth = Month.APRIL
         val rsvSeasonEndDay = 31
 
         // Determine if baby was born after RSV season
@@ -392,11 +382,7 @@ class OPEngine(
                 firstSeasonStart = LocalDate.of(birthdate.year, rsvSeasonStartMonth, rsvSeasonStartDay),
                 firstSeasonEnd = LocalDate.of(birthdate.year + 1, rsvSeasonEndMonth, rsvSeasonEndDay),
                 secondSeasonStart = LocalDate.of(birthdate.year + 1, rsvSeasonStartMonth, rsvSeasonStartDay),
-                secondSeasonEnd = LocalDate.of(birthdate.year + 2, rsvSeasonEndMonth, rsvSeasonEndDay),
-                extendedFirstSeasonStart = LocalDate.of(birthdate.year, extendedRsvSeasonStartMonth, rsvSeasonStartDay),
-                extendedFirstSeasonEnd = LocalDate.of(birthdate.year + 1, extendedRsvSeasonEndMonth, rsvSeasonEndDay - 1),
-                extendedSecondSeasonStart = LocalDate.of(birthdate.year + 1, extendedRsvSeasonStartMonth, rsvSeasonStartDay),
-                extendedSecondSeasonEnd = LocalDate.of(birthdate.year + 2, extendedRsvSeasonEndMonth, rsvSeasonEndDay - 1)
+                secondSeasonEnd = LocalDate.of(birthdate.year + 2, rsvSeasonEndMonth, rsvSeasonEndDay)
             )
         } else {
             // Baby born before April 1st (October 1st to March 31st)
@@ -404,11 +390,7 @@ class OPEngine(
                 firstSeasonStart = LocalDate.of(birthdate.year - 1, rsvSeasonStartMonth, rsvSeasonStartDay),
                 firstSeasonEnd = LocalDate.of(birthdate.year, rsvSeasonEndMonth, rsvSeasonEndDay),
                 secondSeasonStart = LocalDate.of(birthdate.year, rsvSeasonStartMonth, rsvSeasonStartDay),
-                secondSeasonEnd = LocalDate.of(birthdate.year + 1, rsvSeasonEndMonth, rsvSeasonEndDay),
-                extendedFirstSeasonStart = LocalDate.of(birthdate.year - 1, extendedRsvSeasonStartMonth, rsvSeasonStartDay),
-                extendedFirstSeasonEnd = LocalDate.of(birthdate.year, extendedRsvSeasonEndMonth, rsvSeasonEndDay - 1),
-                extendedSecondSeasonStart = LocalDate.of(birthdate.year, extendedRsvSeasonStartMonth, rsvSeasonStartDay),
-                extendedSecondSeasonEnd = LocalDate.of(birthdate.year + 1, extendedRsvSeasonEndMonth, rsvSeasonEndDay - 1)
+                secondSeasonEnd = LocalDate.of(birthdate.year + 1, rsvSeasonEndMonth, rsvSeasonEndDay)
             )
         }
     }

--- a/src/main/kotlin/com/connexin/ice/wrapper/service/op/OPEngine.kt
+++ b/src/main/kotlin/com/connexin/ice/wrapper/service/op/OPEngine.kt
@@ -107,8 +107,6 @@ class OPEngine(
         cmds.add(CommandFactory.newSetGlobal("vaccineGroupExclusions", listOf<Any>()))
         cmds.add(CommandFactory.newSetGlobal("rsvSeasonStartMonthDay", org.joda.time.MonthDay(10, 1)))
         cmds.add(CommandFactory.newSetGlobal("rsvSeasonEndMonthDay", org.joda.time.MonthDay(3, 31)))
-        cmds.add(CommandFactory.newSetGlobal("extendedRsvSeasonStartMonthDay", org.joda.time.MonthDay(9, 1)))
-        cmds.add(CommandFactory.newSetGlobal("extendedRsvSeasonEndMonthDay", org.joda.time.MonthDay(4, 30)))
         cmds.add(CommandFactory.newSetGlobal("februaryStartMonthDay", org.joda.time.MonthDay(2, 1)))
         cmds.add(CommandFactory.newSetGlobal("isRSVHighRisk", isRsvIndicated == true))
         cmds.add(CommandFactory.newSetGlobal("wasMommyVaxGiven", mommyVaxGiven))
@@ -116,8 +114,8 @@ class OPEngine(
         cmds.add(CommandFactory.newSetGlobal("isMenBHighRisk", isMenBHighRisk))
 
         // Add the calculated dates as globals
-        cmds.add(CommandFactory.newSetGlobal("firstRSVSeasonStart", rsvSeasonDates.firstSeasonStart.toDate()))
-        cmds.add(CommandFactory.newSetGlobal("firstRSVSeasonEnd", rsvSeasonDates.firstSeasonEnd.toDate()))
+//        cmds.add(CommandFactory.newSetGlobal("firstRSVSeasonStart", rsvSeasonDates.firstSeasonStart.toDate()))
+//        cmds.add(CommandFactory.newSetGlobal("firstRSVSeasonEnd", rsvSeasonDates.firstSeasonEnd.toDate()))
         cmds.add(CommandFactory.newSetGlobal("secondRSVSeasonStart", rsvSeasonDates.secondSeasonStart.toDate()))
         cmds.add(CommandFactory.newSetGlobal("secondRSVSeasonEnd", rsvSeasonDates.secondSeasonEnd.toDate()))
 

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Evaluation^RSV.dslr
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Evaluation^RSV.dslr
@@ -63,37 +63,43 @@ global java.util.Date secondRSVSeasonEnd
 rule "RSV: Evaluate the RSV Injection as Outside RSV Season if it does not fall within the Season Start and Stop Dates"
 	agenda-group "HistoryEvaluation^customEvaluationRule"
 	activation-group "doseInSeasonCheck"
-	salience 60
+	salience 50
 	when
 		There is an Administered Shot $currentShot that needs to be evaluated
 			- the shot belongs to the vaccine group "VACCINE_GROUP_CONCEPT.905"
-			- the vaccine administered a member of ("ICE306", "ICE307")
 			- make note of the date this shot was administered as $currentShotDate
 			- make note of the Associated Series as $associatedTargetSeries
-    The Given date $currentShotDate does not fall within the ranges of extendedRsvSeasonStartMonthDay and extendedRsvSeasonEndMonthDay
+    The Given date $currentShotDate does not fall within the ranges of rsvSeasonStartMonthDay and rsvSeasonEndMonthDay
 	then
 		Include the reason for shot $currentShot Invalid due to "Outside RSV Season"
 		Record that this dose rule was Processed for the TargetDose $currentShot
 		Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
 
-rule "RSV: Validate non-Beyfortus RSV vaccines during regular season"
-  agenda-group "HistoryEvaluation^customEvaluationRule"
-  activation-group "doseInSeasonCheck"
-  salience 50
-  when
-    There is an Administered Shot $currentShot that needs to be evaluated
-      - the shot belongs to the vaccine group "VACCINE_GROUP_CONCEPT.905"
-      - the vaccine administered not a member of ("ICE306", "ICE307")
-      - make note of the date this shot was administered as $currentShotDate
-      - make note of the Associated Series as $associatedTargetSeries
-
-      // Regular season check (Oct 1 - Mar 31)
-      The Given date $currentShotDate does not fall within the ranges of rsvSeasonStartMonthDay and rsvSeasonEndMonthDay
-  then
-    Include the reason for shot $currentShot Invalid due to "Outside RSV Season"
-    Record that this dose rule was Processed for the TargetDose $currentShot
-    Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
+rule "RSV: Evaluate RSV Beyfortus (nirsevimab) as VALID when HighRisk as early as September 1 and as late as April 30"
+	agenda-group "HistoryEvaluation^postEvaluationCheck"
+	activation-group "doseInSeasonCheck"
+	salience 50
+	dialect "mvel"
+  no-loop true
+	when
+		There is an Administered Shot $currentShot
+			- the shot belongs to the vaccine group "VACCINE_GROUP_CONCEPT.905"
+			- the vaccine administered a member of ("ICE306", "ICE307")
+      - that has already been evaluated and whose shot validity is INVALID
+      - make note of invalid evaluation reasons for this shot as $collectionOfInvalidReasons
+      - the size of the collection $collectionOfInvalidReasons is == 1
+      - the collection $collectionOfInvalidReasons contains "EVALUATION_REASON_CONCEPT.OUTSIDE_SEASON"
+			- make note of the date this shot was administered as $currentShotDate
+			- make note of the Associated Series as $associatedTargetSeries
+		Confirm the variable isRSVHighRisk is == true
+    The Given date $currentShotDate falls within the ranges of extendedRsvSeasonStartMonthDay and extendedRsvSeasonEndMonthDay
+	then
+    Remove all evaluation reasons from shot $currentShot
+    Set the Shot Status of $currentShot to Valid
+    Refresh all facts in the shot $currentShot
+		Record that this dose rule was Processed for the TargetDose $currentShot
+		Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
 
 rule "RSV(Synagis): If Given Synagis and patient is NOT on RSV High risk, evaluate it as INVALID dose"
@@ -211,7 +217,7 @@ rule "RSV(Beyfortus): If the vaccine was administered on season and mommy vax wa
 			- the administration date of the shot is < $dateAt8mOld
 			- make note of the associated series as $associatedTargetSeries
 			- make note of the date this shot was administered as $currentShotDate
-    The Given date $currentShotDate falls within the ranges of extendedRsvSeasonStartMonthDay and extendedRsvSeasonEndMonthDay
+    The Given date $currentShotDate falls within the ranges of rsvSeasonStartMonthDay and rsvSeasonEndMonthDay
     Confirm the variable wasMommyVaxGiven is == true
 	then
 		Include the reason for shot $currentShot Invalid due to "Not Recommended due to Mother Vaccine Documented"

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Evaluation^RSV.dslr
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Evaluation^RSV.dslr
@@ -52,8 +52,6 @@ expander ../../knowledgeCommon/org.cdsframework.ice/org.cdsframework^ICE^1.0.0.d
 global java.util.Date evalTime
 global org.joda.time.MonthDay rsvSeasonStartMonthDay
 global org.joda.time.MonthDay rsvSeasonEndMonthDay
-global org.joda.time.MonthDay extendedRsvSeasonStartMonthDay
-global org.joda.time.MonthDay extendedRsvSeasonEndMonthDay
 global java.lang.Boolean isRSVHighRisk
 global java.lang.Boolean wasMommyVaxGiven
 global java.util.Date secondRSVSeasonStart
@@ -76,31 +74,6 @@ rule "RSV: Evaluate the RSV Injection as Outside RSV Season if it does not fall 
 		Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
 end
 
-rule "RSV: Evaluate RSV Beyfortus (nirsevimab) as VALID when HighRisk as early as September 1 and as late as April 30"
-	agenda-group "HistoryEvaluation^postEvaluationCheck"
-	activation-group "doseInSeasonCheck"
-	salience 50
-	dialect "mvel"
-  no-loop true
-	when
-		There is an Administered Shot $currentShot
-			- the shot belongs to the vaccine group "VACCINE_GROUP_CONCEPT.905"
-			- the vaccine administered a member of ("ICE306", "ICE307")
-      - that has already been evaluated and whose shot validity is INVALID
-      - make note of invalid evaluation reasons for this shot as $collectionOfInvalidReasons
-      - the size of the collection $collectionOfInvalidReasons is == 1
-      - the collection $collectionOfInvalidReasons contains "EVALUATION_REASON_CONCEPT.OUTSIDE_SEASON"
-			- make note of the date this shot was administered as $currentShotDate
-			- make note of the Associated Series as $associatedTargetSeries
-		Confirm the variable isRSVHighRisk is == true
-    The Given date $currentShotDate falls within the ranges of extendedRsvSeasonStartMonthDay and extendedRsvSeasonEndMonthDay
-	then
-    Remove all evaluation reasons from shot $currentShot
-    Set the Shot Status of $currentShot to Valid
-    Refresh all facts in the shot $currentShot
-		Record that this dose rule was Processed for the TargetDose $currentShot
-		Log that this dose rule fired for the dose $currentShot in the Series $associatedTargetSeries
-end
 
 rule "RSV(Synagis): If Given Synagis and patient is NOT on RSV High risk, evaluate it as INVALID dose"
 	agenda-group "HistoryEvaluation^customEvaluationRule"

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Recommendation^RSV.dslr
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^Recommendation^RSV.dslr
@@ -43,18 +43,8 @@ global java.util.Date evalTime
 global org.joda.time.MonthDay rsvSeasonStartMonthDay
 global org.joda.time.MonthDay rsvSeasonEndMonthDay
 global org.joda.time.MonthDay februaryStartMonthDay
-global org.joda.time.MonthDay extendedRsvSeasonStartMonthDay
-global org.joda.time.MonthDay extendedRsvSeasonEndMonthDay
 global java.lang.Boolean isRSVHighRisk
 global java.lang.Boolean wasMommyVaxGiven
-global java.util.Date firstRSVSeasonStart
-global java.util.Date firstRSVSeasonEnd
-global java.util.Date secondRSVSeasonStart
-global java.util.Date secondRSVSeasonEnd
-global java.util.Date extendedFirstRSVSeasonStart
-global java.util.Date extendedFirstRSVSeasonEnd
-global java.util.Date extendedSecondRSVSeasonStart
-global java.util.Date extendedSecondRSVSeasonEnd
 
 expander ../../knowledgeCommon/org.cdsframework.ice/org.cdsframework^ICE^1.0.0.dsl
 
@@ -129,48 +119,8 @@ rule "RSV: Ideal Date High Recommendation Outside season, Move recommendation da
     Log that this Series Rule fired for the Series $evaluatedTargetSeries
 end
 
-rule "RSV: Complete series after 2 valid doses (last valid dose beyfortus in the second season)"
-  agenda-group "RecommendationForecast^postCustomRecommendationCheck"
-  salience 100 // Higher priority
-  when
-    The Patient information $patientInfo must be known to complete writing this rule
-      - make note of the date as $dateAt8MonthsAge when the patient is "8m" of age
-    There is a Series $targetSeries
-      - the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.905"
-      - the series is not complete
-    There is an Administered Shot $currentShot
-      - the shot belongs to the vaccine group "VACCINE_GROUP_CONCEPT.905"
-      - the vaccine administered a member of ("ICE307")
-      - that has already been evaluated and whose shot validity is VALID or ACCEPTED
-      - the shot is not ignored
-      - make note of the date this shot was administered as $currentShotAdministrationDate
-      - make note of the associated series as $associatedTargetSeries
-
-    There is an Administered Shot $previousBeyfortusShot
-      - the shot belongs to the vaccine group "VACCINE_GROUP_CONCEPT.905"
-      - the vaccine administered a member of ("ICE93", "ICE306", "ICE307")
-      - that has already been evaluated and whose shot validity is VALID or ACCEPTED
-      - the shot is not ignored
-      - the administration date of the shot is < $dateAt8MonthsAge
-      - the administration date of the shot is < $currentShotAdministrationDate
-
-    The given date $currentShotAdministrationDate falls within the ranges of extendedRsvSeasonStartMonthDay and extendedRsvSeasonEndMonthDay
-
-    // Check if the dose was administered in the second RSV season
-    Confirm the date $currentShotAdministrationDate is on the same date or after extendedSecondRSVSeasonStart
-    Confirm the date $currentShotAdministrationDate is on the same date or before extendedSecondRSVSeasonEnd
-
-  then
-    Create a Recommendation as $recommendation with Status RecommendationStatus.NOT_RECOMMENDED for the Series $targetSeries
-    Set the Recommendation Reason for $recommendation to "RECOMMENDATION_REASON_CONCEPT.COMPLETE"
-    Include the Recommendation $recommendation for Consideration in the final Forecast of the Series
-    Mark the Series $targetSeries Complete
-    Record that this Series Rule was Processed for the TargetSeries $targetSeries
-end
-
 rule "RSV: No longer recommend RSV Immunization starting 20 months old using earliest recommended date"
 	agenda-group "RecommendationForecast^postCustomRecommendationCheck"
-	salience 50
 	when
 		There is a Series $targetSeries
 			- the Series belongs to the Vaccine Group "VACCINE_GROUP_CONCEPT.905"


### PR DESCRIPTION
PEDS-6328 Revert: Remove RSV changes intended for a future release. These commits are being reverted to keep the develop branch clean for the upcoming release