### PR TITLE
:bug: PEDS-6931 Logic engine is switching from HepA2DoseSeries to HepAAdult3DoseSeries 

### DIFF
--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^SeriesSelection.drl
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/gov.nyc.cir^ICE^1.0.0^SeriesSelection.drl
@@ -1616,10 +1616,10 @@ rule "SeriesSelection.SelectHepAAdult3DoseSeries when 2 dose series is not suffi
 	salience 80
 	activation-group "HepASeriesSelectionCheck"
 	when
-	  EvaluatedPerson($dateAt18yrs : TimePeriod.addTimePeriod(demographics.birthTime, "18y-4d"))
+	  EvaluatedPerson($dateAt19yrs : TimePeriod.addTimePeriod(demographics.birthTime, "19y-4d"))
 		$tss : TargetSeriesSelection(seriesSelectionVaccineGroup == "VACCINE_GROUP_CONCEPT.810", seriesSelectionStatus == SeriesSelectionStatus.SERIES_SELECTION_IN_PROCESS)
 		not TargetSeries(seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.810", selectedSeries == true)
-		exists TargetDose(associatedTargetSeries.seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.810", administrationDate >= $dateAt18yrs)
+		exists TargetDose(associatedTargetSeries.seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.810", administrationDate >= $dateAt19yrs)
 		$ts : TargetSeries(seriesRules.vaccineGroup == "VACCINE_GROUP_CONCEPT.810", seriesRules.seriesName == "HepAAdult3DoseSeries",	selectedSeries == false)
 	then
 		String _RULENAME = kcontext.rule.name;

--- a/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/HepAAdult3DoseSeries.xml
+++ b/src/main/resources/rules/v1.39.2.3/knowledgeModule/gov.nyc.cir.ice/ice-supporting-data/Series/HepAAdult3DoseSeries.xml
@@ -22,8 +22,8 @@
     <ns2:vaccineGroup code="810" codeSystem="2.16.840.1.113883.3.795.12.100.1" codeSystemName="ICE Vaccine Group" displayName="HepA"/>
     <ns2:iceSeriesDose>
         <ns2:doseNumber>1</ns2:doseNumber>
-        <ns2:absoluteMinimumAge>18y</ns2:absoluteMinimumAge>
-        <ns2:minimumAge>18y</ns2:minimumAge>
+        <ns2:absoluteMinimumAge>19y-4d</ns2:absoluteMinimumAge>
+        <ns2:minimumAge>19y</ns2:minimumAge>
         <ns2:doseVaccine>
             <ns2:preferred>true</ns2:preferred>
             <ns2:vaccine code="31" codeSystem="2.16.840.1.113883.12.292" codeSystemName="CVX" displayName="Hep A, pediatric, NOS"/>


### PR DESCRIPTION
🐛 PEDS-6931 Logic engine is switching from HepA2DoseSeries to HepAAdult3DoseSeries at the 18th birthday instead of the 19th birthday causing the problem